### PR TITLE
admin customer account manager page.

### DIFF
--- a/models.py
+++ b/models.py
@@ -189,6 +189,22 @@ class User(db.Model):
         default=utc_now_naive,
     )
 
+
+class Voucher(db.Model):
+    __tablename__ = "vouchers"
+
+    id = db.Column(db.Integer, primary_key=True)
+    code = db.Column(db.String(32), nullable=False, unique=True, index=True)
+    value_cents = db.Column(db.Integer, nullable=False)
+    label = db.Column(db.String(120), nullable=False)
+    created_at = db.Column(
+        db.DateTime,
+        nullable=False,
+        default=utc_now_naive,
+        index=True,
+    )
+
+
 class OrderNotification(db.Model):
     __tablename__ = "order_notifications"
 

--- a/models.py
+++ b/models.py
@@ -197,6 +197,7 @@ class Voucher(db.Model):
     code = db.Column(db.String(32), nullable=False, unique=True, index=True)
     value_cents = db.Column(db.Integer, nullable=False)
     label = db.Column(db.String(120), nullable=False)
+    description = db.Column(db.Text, nullable=True)
     created_at = db.Column(
         db.DateTime,
         nullable=False,
@@ -234,6 +235,11 @@ class OrderNotification(db.Model):
 def _sync_legacy_schema() -> None:
     inspector = inspect(db.engine)
     tables = set(inspector.get_table_names())
+    if "vouchers" in tables:
+        voucher_columns = {column["name"] for column in inspector.get_columns("vouchers")}
+        with db.engine.begin() as conn:
+            if "description" not in voucher_columns:
+                conn.execute(text("ALTER TABLE vouchers ADD COLUMN description TEXT"))
     if "orders" not in tables:
         return
 

--- a/models.py
+++ b/models.py
@@ -198,6 +198,11 @@ class Voucher(db.Model):
     value_cents = db.Column(db.Integer, nullable=False)
     label = db.Column(db.String(120), nullable=False)
     description = db.Column(db.Text, nullable=True)
+    subtitle = db.Column(db.String(180), nullable=True)
+    terms = db.Column(db.Text, nullable=True)
+    included_items = db.Column(db.Text, nullable=True)
+    expires_at = db.Column(db.String(40), nullable=True)
+    footer_note = db.Column(db.Text, nullable=True)
     created_at = db.Column(
         db.DateTime,
         nullable=False,
@@ -240,6 +245,16 @@ def _sync_legacy_schema() -> None:
         with db.engine.begin() as conn:
             if "description" not in voucher_columns:
                 conn.execute(text("ALTER TABLE vouchers ADD COLUMN description TEXT"))
+            if "subtitle" not in voucher_columns:
+                conn.execute(text("ALTER TABLE vouchers ADD COLUMN subtitle VARCHAR(180)"))
+            if "terms" not in voucher_columns:
+                conn.execute(text("ALTER TABLE vouchers ADD COLUMN terms TEXT"))
+            if "included_items" not in voucher_columns:
+                conn.execute(text("ALTER TABLE vouchers ADD COLUMN included_items TEXT"))
+            if "expires_at" not in voucher_columns:
+                conn.execute(text("ALTER TABLE vouchers ADD COLUMN expires_at VARCHAR(40)"))
+            if "footer_note" not in voucher_columns:
+                conn.execute(text("ALTER TABLE vouchers ADD COLUMN footer_note TEXT"))
     if "orders" not in tables:
         return
 

--- a/routes/admin.py
+++ b/routes/admin.py
@@ -99,6 +99,8 @@ def _voucher_payload(voucher: Voucher) -> dict:
     return {
         "code": voucher.code,
         "label": voucher.label,
+        "description": voucher.description
+        or "Use this voucher for MCQ street-food favourites such as banh mi, Vietnamese coffee, pho, rice bowls, and pickup combos.",
         "value_display": f"${dollars}",
         "created_label": voucher.created_at.strftime("%d %b %Y"),
         "banh_mi_count": banh_mi_count,
@@ -308,10 +310,13 @@ def admin_vouchers():
             dollars = 10
         if dollars not in VOUCHER_VALUES:
             dollars = 10
+        description = request.form.get("description", "").strip()
         voucher = Voucher(
             code=_new_voucher_code(),
             value_cents=dollars * 100,
             label=f"MCQ ${dollars} Digital Voucher",
+            description=description
+            or "Use this voucher for MCQ street-food favourites such as banh mi, Vietnamese coffee, pho, rice bowls, and pickup combos.",
         )
         db.session.add(voucher)
         db.session.commit()

--- a/routes/admin.py
+++ b/routes/admin.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from flask import Blueprint, render_template
 
-from models import FULFILLMENT_TYPES, ORDER_STATUS_SEQUENCE, Order
+from models import FULFILLMENT_TYPES, ORDER_STATUS_SEQUENCE, Order, db
 from routes.auth import admin_required
 
 
@@ -40,11 +40,19 @@ def admin_queue() -> str:
         .order_by(Order.created_at.asc())
         .all()
     )
-    instant_source = [order for order in active_orders if order.fulfillment_type == FULFILLMENT_TYPES[0]]
+    instant_source = [
+        order
+        for order in active_orders
+        if order.fulfillment_type == FULFILLMENT_TYPES[0]
+    ]
     instant_source.sort(key=lambda order: order.queue_number or 999999)
     instant_orders = [_serialize_admin_order(order) for order in instant_source]
 
-    scheduled_source = [order for order in active_orders if order.fulfillment_type == FULFILLMENT_TYPES[1]]
+    scheduled_source = [
+        order
+        for order in active_orders
+        if order.fulfillment_type == FULFILLMENT_TYPES[1]
+    ]
     scheduled_source.sort(key=lambda order: order.pickup_at)
     scheduled_orders = [_serialize_admin_order(order) for order in scheduled_source]
 
@@ -54,3 +62,16 @@ def admin_queue() -> str:
         scheduled_orders=scheduled_orders,
         order_statuses=list(ORDER_STATUS_SEQUENCE),
     )
+
+
+@admin_bp.get("/customers")
+@admin_required
+def admin_customers():
+    customer = (
+        db.session.query(
+            Order.customer_name, Order.customer_email, Order.customer_phone
+        )
+        .distinct()
+        .all()
+    )
+    return render_template("admin/customers.html", customers=customer)

--- a/routes/admin.py
+++ b/routes/admin.py
@@ -1,18 +1,20 @@
 from __future__ import annotations
 
 import json
+import secrets
 from pathlib import Path
 
 from flask import Blueprint, redirect, render_template, request, url_for
 from sqlalchemy import func, or_, select
 
 from menu_catalog import load_enriched_menu
-from models import FULFILLMENT_TYPES, ORDER_STATUS_SEQUENCE, Order, User, db
+from models import FULFILLMENT_TYPES, ORDER_STATUS_SEQUENCE, Order, User, Voucher, db
 from routes.auth import admin_required
 
 
 admin_bp = Blueprint("admin", __name__, url_prefix="/admin")
 _ROOT_DIR = Path(__file__).resolve().parent.parent
+VOUCHER_VALUES = (10, 20, 30, 40, 50, 80, 100, 150, 200)
 
 
 def _menu_path() -> Path:
@@ -87,6 +89,29 @@ def _serialize_admin_order(order: Order) -> dict:
         "kitchen_notes": order.kitchen_notes,
         "next_statuses": next_statuses,
     }
+
+
+def _voucher_payload(voucher: Voucher) -> dict:
+    dollars = voucher.value_cents // 100
+    banh_mi_count = max(1, voucher.value_cents // 1000)
+    coffee_count = max(1, voucher.value_cents // 600)
+    combo_count = max(1, voucher.value_cents // 1600)
+    return {
+        "code": voucher.code,
+        "label": voucher.label,
+        "value_display": f"${dollars}",
+        "created_label": voucher.created_at.strftime("%d %b %Y"),
+        "banh_mi_count": banh_mi_count,
+        "coffee_count": coffee_count,
+        "combo_count": combo_count,
+    }
+
+
+def _new_voucher_code() -> str:
+    while True:
+        code = f"MCQ-{secrets.token_hex(3).upper()}"
+        if Voucher.query.filter_by(code=code).first() is None:
+            return code
 
 
 @admin_bp.get("/")
@@ -263,6 +288,39 @@ def admin_menu():
         categories=categories,
         items=items,
         available_count=sum(1 for item in items if item["available"]),
+    )
+
+
+@admin_bp.route("/vouchers", methods=["GET", "POST"])
+@admin_required
+def admin_vouchers():
+    if request.method == "POST":
+        raw_value = request.form.get("value", "").strip()
+        try:
+            dollars = int(raw_value)
+        except ValueError:
+            dollars = 10
+        if dollars not in VOUCHER_VALUES:
+            dollars = 10
+        voucher = Voucher(
+            code=_new_voucher_code(),
+            value_cents=dollars * 100,
+            label=f"MCQ ${dollars} Digital Voucher",
+        )
+        db.session.add(voucher)
+        db.session.commit()
+        return redirect(url_for("admin.admin_vouchers", code=voucher.code))
+
+    vouchers = Voucher.query.order_by(Voucher.created_at.desc()).limit(24).all()
+    selected_code = request.args.get("code", "").strip()
+    selected = next((voucher for voucher in vouchers if voucher.code == selected_code), None)
+    if selected is None and vouchers:
+        selected = vouchers[0]
+    return render_template(
+        "admin/vouchers.html",
+        values=VOUCHER_VALUES,
+        vouchers=[_voucher_payload(voucher) for voucher in vouchers],
+        selected_voucher=_voucher_payload(selected) if selected else None,
     )
 
 

--- a/routes/admin.py
+++ b/routes/admin.py
@@ -93,19 +93,28 @@ def _serialize_admin_order(order: Order) -> dict:
 
 def _voucher_payload(voucher: Voucher) -> dict:
     dollars = voucher.value_cents // 100
-    banh_mi_count = max(1, voucher.value_cents // 1000)
-    coffee_count = max(1, voucher.value_cents // 600)
-    combo_count = max(1, voucher.value_cents // 1600)
+    included_items = voucher.included_items or (
+        f"{max(1, voucher.value_cents // 1000)} banh mi serves approx.\n"
+        f"{max(1, voucher.value_cents // 600)} Vietnamese coffees approx.\n"
+        f"{max(1, voucher.value_cents // 1600)} banh mi + coffee combos approx."
+    )
     return {
+        "id": voucher.id,
         "code": voucher.code,
         "label": voucher.label,
+        "subtitle": voucher.subtitle or "For lucky customer",
+        "terms": voucher.terms
+        or "This gift certificate is not redeemable for cash.\nOne time use only.",
         "description": voucher.description
-        or "Use this voucher for MCQ street-food favourites such as banh mi, Vietnamese coffee, pho, rice bowls, and pickup combos.",
+        or f"This voucher entitles the bearer to {dollars} dollars worth of MCQ Vietnamese Street Food.",
+        "included_items": included_items,
+        "included_lines": [line.strip() for line in included_items.splitlines() if line.strip()],
+        "expires_at": voucher.expires_at or "13 May 2026",
+        "footer_note": voucher.footer_note
+        or "Authorised by MCQ Vietnamese Street Food. For catering or voucher enquiries, please contact the store team.",
         "value_display": f"${dollars}",
+        "value": dollars,
         "created_label": voucher.created_at.strftime("%d %b %Y"),
-        "banh_mi_count": banh_mi_count,
-        "coffee_count": coffee_count,
-        "combo_count": combo_count,
     }
 
 
@@ -303,22 +312,37 @@ def admin_menu():
 @admin_required
 def admin_vouchers():
     if request.method == "POST":
+        action = request.form.get("action", "create").strip()
         raw_value = request.form.get("value", "").strip()
         try:
             dollars = int(raw_value)
         except ValueError:
             dollars = 10
-        if dollars not in VOUCHER_VALUES:
+        if action != "update" and dollars not in VOUCHER_VALUES:
             dollars = 10
-        description = request.form.get("description", "").strip()
-        voucher = Voucher(
-            code=_new_voucher_code(),
-            value_cents=dollars * 100,
-            label=f"MCQ ${dollars} Digital Voucher",
-            description=description
-            or "Use this voucher for MCQ street-food favourites such as banh mi, Vietnamese coffee, pho, rice bowls, and pickup combos.",
-        )
-        db.session.add(voucher)
+        if action == "update" and dollars < 1:
+            dollars = 10
+        voucher = None
+        if action == "update":
+            voucher_id = request.form.get("voucher_id", "").strip()
+            if voucher_id.isdigit():
+                voucher = Voucher.query.get(int(voucher_id))
+        if voucher is None:
+            voucher = Voucher(code=_new_voucher_code(), value_cents=dollars * 100, label="")
+            db.session.add(voucher)
+        requested_code = request.form.get("code", "").strip().upper()
+        if requested_code and requested_code != voucher.code:
+            existing = Voucher.query.filter_by(code=requested_code).first()
+            if existing is None:
+                voucher.code = requested_code
+        voucher.value_cents = dollars * 100
+        voucher.label = request.form.get("label", "").strip() or f"${dollars} Catering Voucher"
+        voucher.subtitle = request.form.get("subtitle", "").strip() or "For lucky customer"
+        voucher.description = request.form.get("description", "").strip()
+        voucher.terms = request.form.get("terms", "").strip()
+        voucher.included_items = request.form.get("included_items", "").strip()
+        voucher.expires_at = request.form.get("expires_at", "").strip() or "13 May 2026"
+        voucher.footer_note = request.form.get("footer_note", "").strip()
         db.session.commit()
         return redirect(url_for("admin.admin_vouchers", code=voucher.code))
 

--- a/routes/admin.py
+++ b/routes/admin.py
@@ -125,6 +125,13 @@ def admin_customers():
     customers.sort(key=lambda c: c["name"].lower())
 
     q = request.args.get("q", "").strip()
+    account_type = request.args.get("account_type", "all").strip().lower()
+    if account_type not in {"all", "registered", "guest"}:
+        account_type = "all"
+
+    if account_type != "all":
+        customers = [c for c in customers if c["type"] == account_type]
+
     if q:
         q_lower = q.lower()
         customers = [
@@ -140,6 +147,7 @@ def admin_customers():
         "admin/customers.html",
         customers=customers,
         search_query=q,
+        account_type=account_type,
         registered_count=registered_count,
         guest_count=guest_count,
     )

--- a/routes/admin.py
+++ b/routes/admin.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
-from flask import Blueprint, render_template
+from flask import Blueprint, render_template, request
+from sqlalchemy import func
 
-from models import FULFILLMENT_TYPES, ORDER_STATUS_SEQUENCE, Order, db
+from models import FULFILLMENT_TYPES, ORDER_STATUS_SEQUENCE, Order, User, db
 from routes.auth import admin_required
 
 
@@ -67,11 +68,78 @@ def admin_queue() -> str:
 @admin_bp.get("/customers")
 @admin_required
 def admin_customers():
-    customer = (
+    registered_email_subq = (
+        db.session.query(User.email).filter(User.role == "customer").subquery()
+    )
+
+    registered_rows = (
         db.session.query(
-            Order.customer_name, Order.customer_email, Order.customer_phone
+            User.name,
+            User.email,
+            User.created_at,
+            func.count(Order.id).label("order_count"),
+            func.coalesce(func.sum(Order.total_cents), 0).label("total_spent_cents"),
         )
-        .distinct()
+        .outerjoin(Order, User.email == Order.customer_email)
+        .filter(User.role == "customer")
+        .group_by(User.id)
         .all()
     )
-    return render_template("admin/customers.html", customers=customer)
+
+    guest_rows = (
+        db.session.query(
+            Order.customer_name.label("name"),
+            Order.customer_email.label("email"),
+            func.count(Order.id).label("order_count"),
+            func.sum(Order.total_cents).label("total_spent_cents"),
+        )
+        .filter(~Order.customer_email.in_(registered_email_subq))
+        .group_by(Order.customer_email)
+        .all()
+    )
+
+    customers = []
+    for r in registered_rows:
+        customers.append(
+            {
+                "name": r.name,
+                "email": r.email,
+                "joined": r.created_at.strftime("%-d %b %Y") if r.created_at else "—",
+                "order_count": r.order_count,
+                "total_spent": f"${r.total_spent_cents / 100:.2f}",
+                "type": "registered",
+            }
+        )
+    for r in guest_rows:
+        customers.append(
+            {
+                "name": r.name,
+                "email": r.email,
+                "joined": "—",
+                "order_count": r.order_count,
+                "total_spent": f"${(r.total_spent_cents or 0) / 100:.2f}",
+                "type": "guest",
+            }
+        )
+
+    customers.sort(key=lambda c: c["name"].lower())
+
+    q = request.args.get("q", "").strip()
+    if q:
+        q_lower = q.lower()
+        customers = [
+            c
+            for c in customers
+            if q_lower in c["name"].lower() or q_lower in c["email"].lower()
+        ]
+
+    registered_count = sum(1 for c in customers if c["type"] == "registered")
+    guest_count = sum(1 for c in customers if c["type"] == "guest")
+
+    return render_template(
+        "admin/customers.html",
+        customers=customers,
+        search_query=q,
+        registered_count=registered_count,
+        guest_count=guest_count,
+    )

--- a/routes/admin.py
+++ b/routes/admin.py
@@ -114,23 +114,35 @@ def _new_voucher_code() -> str:
             return code
 
 
-@admin_bp.get("/")
-@admin_required
-def admin_dashboard() -> str:
-    monthly_rows = (
+def _income_rows(period_expr, *, limit: int) -> list[dict]:
+    rows = (
         db.session.query(
-            func.strftime("%Y-%m", Order.created_at).label("month"),
+            period_expr.label("period"),
             func.count(Order.id).label("order_count"),
             func.coalesce(func.sum(Order.total_cents), 0).label("revenue_cents"),
         )
-        .group_by("month")
-        .order_by(func.strftime("%Y-%m", Order.created_at).desc())
-        .limit(6)
+        .group_by("period")
+        .order_by(period_expr.desc())
+        .limit(limit)
         .all()
     )
-    monthly_rows = list(reversed(monthly_rows))
-    max_monthly_revenue = max((row.revenue_cents for row in monthly_rows), default=0) or 1
+    rows = list(reversed(rows))
+    max_revenue = max((row.revenue_cents for row in rows), default=0) or 1
+    return [
+        {
+            "period": row.period,
+            "order_count": row.order_count,
+            "revenue_display": f"${row.revenue_cents / 100:.2f}",
+            "bar_height": max(6, round((row.revenue_cents / max_revenue) * 100)),
+            "bar_width": max(4, round((row.revenue_cents / max_revenue) * 100)),
+        }
+        for row in rows
+    ]
 
+
+@admin_bp.get("/")
+@admin_required
+def admin_dashboard() -> str:
     recent_orders = (
         Order.query.order_by(Order.created_at.desc())
         .limit(8)
@@ -147,15 +159,9 @@ def admin_dashboard() -> str:
         completed_orders=completed_orders,
         active_orders=active_orders,
         revenue_display=f"${revenue_cents / 100:.2f}",
-        monthly_report=[
-            {
-                "month": row.month,
-                "order_count": row.order_count,
-                "revenue_display": f"${row.revenue_cents / 100:.2f}",
-                "bar_width": max(4, round((row.revenue_cents / max_monthly_revenue) * 100)),
-            }
-            for row in monthly_rows
-        ],
+        daily_report=_income_rows(func.strftime("%Y-%m-%d", Order.created_at), limit=14),
+        monthly_report=_income_rows(func.strftime("%Y-%m", Order.created_at), limit=8),
+        yearly_report=_income_rows(func.strftime("%Y", Order.created_at), limit=5),
         recent_orders=[_serialize_admin_order(order) for order in recent_orders],
     )
 

--- a/routes/admin.py
+++ b/routes/admin.py
@@ -68,6 +68,9 @@ def admin_queue() -> str:
 @admin_bp.get("/customers")
 @admin_required
 def admin_customers():
+    # NOTE: queries all customers into memory for simplicity.
+    # TODO: refactor pagination at scale.
+
     registered_email_subq = (
         db.session.query(User.email).filter(User.role == "customer").subquery()
     )
@@ -142,6 +145,8 @@ def admin_customers():
 
     registered_count = sum(1 for c in customers if c["type"] == "registered")
     guest_count = sum(1 for c in customers if c["type"] == "guest")
+    # TODO: optimise customer stats aggregation (e.g. compute registered/guest counts in the DB
+    # or in the initial query instead of iterating over the full customers list in Python)
 
     return render_template(
         "admin/customers.html",

--- a/routes/admin.py
+++ b/routes/admin.py
@@ -1,13 +1,69 @@
 from __future__ import annotations
 
-from flask import Blueprint, render_template, request
-from sqlalchemy import func
+import json
+from pathlib import Path
 
+from flask import Blueprint, redirect, render_template, request, url_for
+from sqlalchemy import func, or_, select
+
+from menu_catalog import load_enriched_menu
 from models import FULFILLMENT_TYPES, ORDER_STATUS_SEQUENCE, Order, User, db
 from routes.auth import admin_required
 
 
 admin_bp = Blueprint("admin", __name__, url_prefix="/admin")
+_ROOT_DIR = Path(__file__).resolve().parent.parent
+
+
+def _menu_path() -> Path:
+    return _ROOT_DIR / "static" / "data" / "menu.json"
+
+
+def _read_menu_raw() -> dict:
+    with _menu_path().open(encoding="utf-8") as f:
+        return json.load(f)
+
+
+def _write_menu_raw(data: dict) -> None:
+    with _menu_path().open("w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2, ensure_ascii=False)
+        f.write("\n")
+
+
+def _ingredients_section(ingredients: str) -> dict:
+    return {
+        "label": "Ingredients",
+        "items": [item.strip() for item in ingredients.split(",") if item.strip()],
+    }
+
+
+def _item_ingredients(item: dict) -> str:
+    for section in item.get("sections", []):
+        if str(section.get("label", "")).lower() == "ingredients":
+            return ", ".join(section.get("items", []))
+    return ""
+
+
+def _set_ingredients(item: dict, ingredients: str) -> None:
+    sections = list(item.get("sections", []))
+    cleaned = _ingredients_section(ingredients)
+    for index, section in enumerate(sections):
+        if str(section.get("label", "")).lower() == "ingredients":
+            sections[index] = cleaned
+            break
+    else:
+        sections.insert(0, cleaned)
+    item["sections"] = sections
+
+
+def _find_raw_menu_item(data: dict, item_id: str) -> tuple[dict, dict] | None:
+    enriched = load_enriched_menu(_menu_path())
+    for category_index, category in enumerate(enriched.get("categories", [])):
+        for item_index, item in enumerate(category.get("items", [])):
+            if item.get("id") == item_id:
+                raw_category = data["categories"][category_index]
+                return raw_category, raw_category["items"][item_index]
+    return None
 
 
 def _serialize_admin_order(order: Order) -> dict:
@@ -31,6 +87,52 @@ def _serialize_admin_order(order: Order) -> dict:
         "kitchen_notes": order.kitchen_notes,
         "next_statuses": next_statuses,
     }
+
+
+@admin_bp.get("/")
+@admin_required
+def admin_dashboard() -> str:
+    monthly_rows = (
+        db.session.query(
+            func.strftime("%Y-%m", Order.created_at).label("month"),
+            func.count(Order.id).label("order_count"),
+            func.coalesce(func.sum(Order.total_cents), 0).label("revenue_cents"),
+        )
+        .group_by("month")
+        .order_by(func.strftime("%Y-%m", Order.created_at).desc())
+        .limit(6)
+        .all()
+    )
+    monthly_rows = list(reversed(monthly_rows))
+    max_monthly_revenue = max((row.revenue_cents for row in monthly_rows), default=0) or 1
+
+    recent_orders = (
+        Order.query.order_by(Order.created_at.desc())
+        .limit(8)
+        .all()
+    )
+    total_orders = Order.query.count()
+    completed_orders = Order.query.filter(Order.order_status == ORDER_STATUS_SEQUENCE[-1]).count()
+    active_orders = Order.query.filter(Order.order_status != ORDER_STATUS_SEQUENCE[-1]).count()
+    revenue_cents = db.session.query(func.coalesce(func.sum(Order.total_cents), 0)).scalar() or 0
+
+    return render_template(
+        "admin/dashboard.html",
+        total_orders=total_orders,
+        completed_orders=completed_orders,
+        active_orders=active_orders,
+        revenue_display=f"${revenue_cents / 100:.2f}",
+        monthly_report=[
+            {
+                "month": row.month,
+                "order_count": row.order_count,
+                "revenue_display": f"${row.revenue_cents / 100:.2f}",
+                "bar_width": max(4, round((row.revenue_cents / max_monthly_revenue) * 100)),
+            }
+            for row in monthly_rows
+        ],
+        recent_orders=[_serialize_admin_order(order) for order in recent_orders],
+    )
 
 
 @admin_bp.get("/orders/queue")
@@ -65,15 +167,112 @@ def admin_queue() -> str:
     )
 
 
+@admin_bp.get("/orders")
+@admin_required
+def admin_orders() -> str:
+    q = request.args.get("q", "").strip()
+    status = request.args.get("status", "").strip()
+    fulfillment = request.args.get("fulfillment", "").strip().lower()
+
+    query = Order.query
+    if status in ORDER_STATUS_SEQUENCE:
+        query = query.filter(Order.order_status == status)
+    if fulfillment in FULFILLMENT_TYPES:
+        query = query.filter(Order.fulfillment_type == fulfillment)
+    if q:
+        like = f"%{q.lower()}%"
+        query = query.filter(
+            or_(
+                func.lower(Order.order_number).like(like),
+                func.lower(Order.customer_name).like(like),
+                func.lower(Order.customer_email).like(like),
+            )
+        )
+
+    orders = query.order_by(Order.created_at.desc()).limit(100).all()
+    total_cents = sum(order.total_cents for order in orders)
+    return render_template(
+        "admin/order_list.html",
+        orders=[_serialize_admin_order(order) for order in orders],
+        filters={"q": q, "status": status, "fulfillment": fulfillment},
+        available_statuses=list(ORDER_STATUS_SEQUENCE),
+        fulfillment_types=list(FULFILLMENT_TYPES),
+        total_display=f"${total_cents / 100:.2f}",
+    )
+
+
+@admin_bp.route("/menu", methods=["GET", "POST"])
+@admin_required
+def admin_menu():
+    data = _read_menu_raw()
+    if request.method == "POST":
+        action = request.form.get("action", "").strip()
+        if action == "add":
+            category_id = request.form.get("category_id", "").strip()
+            category = next((cat for cat in data.get("categories", []) if cat.get("id") == category_id), None)
+            if category is not None:
+                item = {
+                    "name": request.form.get("name", "").strip() or "New menu item",
+                    "price": request.form.get("price", "").strip() or "$0",
+                    "summary": request.form.get("summary", "").strip(),
+                    "image": request.form.get("image", "").strip(),
+                    "available": request.form.get("available") == "on",
+                    "sections": [_ingredients_section(request.form.get("ingredients", ""))],
+                }
+                category.setdefault("items", []).append(item)
+                _write_menu_raw(data)
+        elif action == "edit":
+            found = _find_raw_menu_item(data, request.form.get("item_id", ""))
+            if found is not None:
+                _, item = found
+                item["name"] = request.form.get("name", "").strip() or item.get("name", "Menu item")
+                item["price"] = request.form.get("price", "").strip() or item.get("price", "$0")
+                item["summary"] = request.form.get("summary", "").strip()
+                item["image"] = request.form.get("image", "").strip()
+                item["available"] = request.form.get("available") == "on"
+                _set_ingredients(item, request.form.get("ingredients", ""))
+                _write_menu_raw(data)
+        elif action == "delete":
+            found = _find_raw_menu_item(data, request.form.get("item_id", ""))
+            if found is not None:
+                category, item = found
+                category["items"] = [row for row in category.get("items", []) if row is not item]
+                _write_menu_raw(data)
+        data = _read_menu_raw()
+
+    enriched = load_enriched_menu(_menu_path())
+    categories = enriched.get("categories", [])
+    items = []
+    for category in categories:
+        for item in category.get("items", []):
+            items.append(
+                {
+                    "id": item.get("id"),
+                    "name": item.get("name", ""),
+                    "category_id": category.get("id"),
+                    "category_title": category.get("title", ""),
+                    "price": item.get("price", ""),
+                    "summary": item.get("summary", ""),
+                    "image": item.get("image", ""),
+                    "available": item.get("available", True),
+                    "ingredients": _item_ingredients(item),
+                }
+            )
+    return render_template(
+        "admin/menu_manage.html",
+        categories=categories,
+        items=items,
+        available_count=sum(1 for item in items if item["available"]),
+    )
+
+
 @admin_bp.get("/customers")
 @admin_required
 def admin_customers():
     # NOTE: queries all customers into memory for simplicity.
     # TODO: refactor pagination at scale.
 
-    registered_email_subq = (
-        db.session.query(User.email).filter(User.role == "customer").subquery()
-    )
+    registered_email_subq = select(User.email).where(User.role == "customer")
 
     registered_rows = (
         db.session.query(
@@ -111,6 +310,7 @@ def admin_customers():
                 "order_count": r.order_count,
                 "total_spent": f"${r.total_spent_cents / 100:.2f}",
                 "type": "registered",
+                "profile_href": url_for("admin.admin_customer_detail", email=r.email),
             }
         )
     for r in guest_rows:
@@ -122,6 +322,7 @@ def admin_customers():
                 "order_count": r.order_count,
                 "total_spent": f"${(r.total_spent_cents or 0) / 100:.2f}",
                 "type": "guest",
+                "profile_href": url_for("admin.admin_customer_detail", email=r.email),
             }
         )
 
@@ -155,4 +356,44 @@ def admin_customers():
         account_type=account_type,
         registered_count=registered_count,
         guest_count=guest_count,
+    )
+
+
+@admin_bp.route("/customers/<path:email>", methods=["GET", "POST"])
+@admin_required
+def admin_customer_detail(email: str):
+    normalized_email = email.strip().lower()
+    user = User.query.filter(func.lower(User.email) == normalized_email).first()
+    if request.method == "POST" and user is not None:
+        user.name = request.form.get("name", "").strip() or user.name
+        new_email = request.form.get("email", "").strip().lower()
+        if new_email and new_email != user.email:
+            Order.query.filter(func.lower(Order.customer_email) == user.email.lower()).update(
+                {"customer_email": new_email},
+                synchronize_session=False,
+            )
+            user.email = new_email
+            normalized_email = new_email
+        db.session.commit()
+        return redirect(url_for("admin.admin_customer_detail", email=normalized_email))
+
+    orders = (
+        Order.query.filter(func.lower(Order.customer_email) == normalized_email)
+        .order_by(Order.created_at.desc())
+        .all()
+    )
+    total_cents = sum(order.total_cents for order in orders)
+    customer_name = user.name if user else (orders[0].customer_name if orders else normalized_email)
+    return render_template(
+        "admin/customer_detail.html",
+        customer={
+            "name": customer_name,
+            "email": normalized_email,
+            "type": "registered" if user else "guest",
+            "joined": user.created_at.strftime("%-d %b %Y") if user else "Guest customer",
+            "order_count": len(orders),
+            "total_spent": f"${total_cents / 100:.2f}",
+        },
+        user=user,
+        orders=[_serialize_admin_order(order) for order in orders],
     )

--- a/routes/auth.py
+++ b/routes/auth.py
@@ -225,3 +225,15 @@ def logout():
     session.pop(SESSION_USER_KEY, None)
     session.modified = True
     return redirect(url_for("public.home"))
+
+
+@auth_bp.post("/demo/admin-mode")
+def demo_admin_mode():
+    session[SESSION_USER_KEY] = {
+        "name": current_app.config["ADMIN_NAME"],
+        "email": current_app.config["ADMIN_EMAIL"],
+        "role": "admin",
+    }
+    session.modified = True
+    next_url = _safe_next_url(request.form.get("next"))
+    return redirect(next_url or url_for("admin.admin_dashboard"))

--- a/routes/cart_api.py
+++ b/routes/cart_api.py
@@ -64,6 +64,8 @@ def _build_cart_payload(menu: dict) -> dict:
         if not found:
             continue
         cat, item = found
+        if item.get("available", True) is False:
+            continue
         unit = price_to_cents(item.get("price"))
         line_total = unit * qty
         total += line_total
@@ -118,8 +120,12 @@ def add_item():
     if qty < 1:
         return jsonify({"error": "quantity must be at least 1"}), 400
     menu = _menu()
-    if not find_item(menu, item_id):
+    found = find_item(menu, item_id)
+    if not found:
         return jsonify({"error": "Unknown menu item"}), 404
+    _, item = found
+    if item.get("available", True) is False:
+        return jsonify({"error": "This menu item is currently unavailable"}), 409
     lines = _get_lines()
     merged = False
     for row in lines:

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -201,6 +201,24 @@ img {
   box-shadow: 0 22px 36px rgba(255, 106, 19, 0.34);
 }
 
+.header-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.header-actions form {
+  margin: 0;
+}
+
+.header-cta {
+  border: 0;
+  cursor: pointer;
+  font: inherit;
+}
+
 .app-main {
   width: min(var(--page-width), calc(100% - 2rem));
   flex: 1;
@@ -753,6 +771,11 @@ img {
   }
 
   .header-cta {
+    width: 100%;
+  }
+
+  .header-actions,
+  .header-actions form {
     width: 100%;
   }
 

--- a/templates/admin/customer_detail.html
+++ b/templates/admin/customer_detail.html
@@ -1,0 +1,150 @@
+{% extends "base.html" %}
+
+{% block title %}Customer Profile | MCQ Vietnamese Street Food{% endblock %}
+
+{% block head %}
+<style>
+  .admin-customer-profile {
+    display: grid;
+    gap: 1rem;
+  }
+
+  .admin-panel {
+    border-radius: 18px;
+    border: 1px solid rgba(112, 85, 66, 0.12);
+    background: linear-gradient(180deg, rgba(255, 252, 247, 0.98), rgba(248, 236, 220, 0.94)), #fff;
+    box-shadow: 0 18px 36px rgba(53, 30, 20, 0.07);
+    padding: 1rem 1.1rem;
+  }
+
+  .profile-grid,
+  .profile-stats {
+    display: grid;
+    gap: 0.85rem;
+  }
+
+  .profile-grid {
+    grid-template-columns: minmax(0, 0.8fr) minmax(0, 1.2fr);
+  }
+
+  .profile-stats {
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+  }
+
+  .profile-stat {
+    border: 1px solid rgba(112, 85, 66, 0.1);
+    border-radius: 14px;
+    background: rgba(255, 255, 255, 0.72);
+    padding: 0.85rem;
+  }
+
+  .profile-stat strong {
+    display: block;
+    font-family: "Bricolage Grotesque", "Be Vietnam Pro", sans-serif;
+    font-size: 1.25rem;
+  }
+
+  .profile-form {
+    display: grid;
+    gap: 0.65rem;
+  }
+
+  .profile-form input {
+    width: 100%;
+    border-radius: 12px;
+    border: 1px solid rgba(112, 85, 66, 0.18);
+    background: rgba(255, 255, 255, 0.84);
+    box-sizing: border-box;
+    font: inherit;
+    padding: 0.72rem 0.8rem;
+  }
+
+  .order-list {
+    display: grid;
+    gap: 0.55rem;
+  }
+
+  .order-row {
+    display: grid;
+    grid-template-columns: 1fr auto auto;
+    gap: 0.75rem;
+    align-items: center;
+    border: 1px solid rgba(112, 85, 66, 0.1);
+    border-radius: 14px;
+    background: rgba(255, 255, 255, 0.72);
+    padding: 0.78rem 0.9rem;
+  }
+
+  .order-row span,
+  .profile-stat span {
+    color: var(--text-muted);
+  }
+
+  @media (max-width: 900px) {
+    .profile-grid,
+    .profile-stats,
+    .order-row {
+      grid-template-columns: 1fr;
+    }
+  }
+</style>
+{% endblock %}
+
+{% block content %}
+<div class="admin-customer-profile">
+  <section class="admin-panel">
+    <p class="eyebrow">{{ customer.type }} customer</p>
+    <h1 class="section-title">{{ customer.name }}</h1>
+    <p class="section-copy">{{ customer.email }} · {{ customer.joined }}</p>
+    <div class="profile-stats">
+      <div class="profile-stat">
+        <strong>{{ customer.order_count }}</strong>
+        <span>Orders</span>
+      </div>
+      <div class="profile-stat">
+        <strong>{{ customer.total_spent }}</strong>
+        <span>Total spent</span>
+      </div>
+      <div class="profile-stat">
+        <strong>{{ customer.type|title }}</strong>
+        <span>Account type</span>
+      </div>
+    </div>
+  </section>
+
+  <section class="profile-grid">
+    <article class="admin-panel">
+      <p class="eyebrow">Profile</p>
+      {% if user %}
+        <form class="profile-form" method="post" action="{{ url_for('admin.admin_customer_detail', email=customer.email) }}">
+          <label>Name</label>
+          <input name="name" value="{{ user.name }}" />
+          <label>Email</label>
+          <input name="email" value="{{ user.email }}" />
+          <button class="button button--primary" type="submit">Save profile</button>
+        </form>
+      {% else %}
+        <p>Guest customers do not have a registered profile yet. Their order records are still visible here.</p>
+      {% endif %}
+    </article>
+
+    <article class="admin-panel">
+      <p class="eyebrow">Order history</p>
+      <div class="order-list">
+        {% for order in orders %}
+          <div class="order-row">
+            <div>
+              <strong>{{ order.order_number }}</strong>
+              <span>{{ order.pickup_label }} · {{ order.fulfillment_type|title }}</span>
+            </div>
+            <strong>{{ order.total_display }}</strong>
+            <a class="button button--secondary" href="{{ url_for('orders.order_detail', order_number=order.order_number) }}">Open</a>
+          </div>
+        {% else %}
+          <p>No orders for this customer yet.</p>
+        {% endfor %}
+      </div>
+    </article>
+  </section>
+</div>
+{% endblock %}

--- a/templates/admin/customers.html
+++ b/templates/admin/customers.html
@@ -218,6 +218,19 @@
     outline-offset: 2px;
   }
 
+  .admin-search-form .admin-clear-action {
+    color: var(--text-muted);
+    background: transparent;
+    border-color: rgba(112, 85, 66, 0.16);
+    box-shadow: none;
+  }
+
+  .admin-search-form .admin-clear-action:hover {
+    color: var(--brand-red);
+    background: rgba(255, 255, 255, 0.58);
+    box-shadow: none;
+  }
+
   /* Customer rows */
   .admin-customer-list {
     display: grid;
@@ -366,7 +379,7 @@
       </select>
       <button type="submit" class="button button--secondary">Search</button>
       {% if search_query or account_type != "all" %}
-        <a href="{{ url_for('admin.admin_customers') }}" class="button button--secondary">Clear</a>
+        <a href="{{ url_for('admin.admin_customers') }}" class="button button--secondary admin-clear-action">Clear</a>
       {% endif %}
     </form>
 

--- a/templates/admin/customers.html
+++ b/templates/admin/customers.html
@@ -1,13 +1,294 @@
 {% extends "base.html" %}
+
+{% block title %}Customer Accounts | MCQ Vietnamese Street Food{% endblock %}
+
+{% block head %}
+<style>
+  .admin-customers {
+    display: grid;
+    gap: 1.4rem;
+  }
+
+  .admin-panel {
+    padding: clamp(1.2rem, 3vw, 2rem);
+  }
+
+  .admin-hero__grid {
+    position: relative;
+    z-index: 1;
+    display: grid;
+    gap: 1rem;
+  }
+
+  .admin-hero__stats {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 0.85rem;
+  }
+
+  .admin-stat {
+    position: relative;
+    overflow: hidden;
+    border-radius: 26px;
+    border: 1px solid rgba(112, 85, 66, 0.12);
+    background:
+      linear-gradient(180deg, rgba(255, 252, 247, 0.98), rgba(248, 236, 220, 0.94)),
+      #fff;
+    box-shadow: 0 18px 36px rgba(53, 30, 20, 0.07);
+    padding: 1.05rem 1.1rem;
+  }
+
+  .admin-stat strong {
+    display: block;
+    font-family: "Bricolage Grotesque", "Be Vietnam Pro", sans-serif;
+    font-size: 1.4rem;
+  }
+
+  .admin-stat span {
+    color: var(--text-muted);
+    line-height: 1.5;
+  }
+
+  .admin-section {
+    position: relative;
+    overflow: hidden;
+    border-radius: 26px;
+    border: 1px solid rgba(112, 85, 66, 0.12);
+    background:
+      linear-gradient(180deg, rgba(255, 252, 247, 0.98), rgba(248, 236, 220, 0.94)),
+      #fff;
+    box-shadow: 0 18px 36px rgba(53, 30, 20, 0.07);
+    padding: 1.4rem 1.5rem;
+  }
+
+  .admin-section__header {
+    margin-bottom: 1.2rem;
+  }
+
+  .admin-section__header h2 {
+    margin: 0.24rem 0 0;
+    font-family: "Bricolage Grotesque", "Be Vietnam Pro", sans-serif;
+    font-size: clamp(1.3rem, 2vw, 1.8rem);
+  }
+
+  .admin-section__header p {
+    margin: 0.35rem 0 0;
+    color: var(--text-muted);
+  }
+
+  /* Search */
+  .admin-search-form {
+    display: flex;
+    gap: 0.65rem;
+    align-items: center;
+    margin-bottom: 1.2rem;
+  }
+
+  .admin-search-form input[type="search"] {
+    flex: 1;
+    padding: 0.65rem 1rem;
+    border-radius: 999px;
+    border: 1px solid rgba(112, 85, 66, 0.2);
+    background: rgba(255, 255, 255, 0.8);
+    font-family: "Be Vietnam Pro", sans-serif;
+    font-size: 0.95rem;
+    color: var(--text-main);
+    outline: none;
+    transition: border-color 0.18s;
+  }
+
+  .admin-search-form input[type="search"]:focus {
+    border-color: var(--brand-orange);
+  }
+
+  .admin-search-form button {
+    flex-shrink: 0;
+  }
+
+  /* Customer rows */
+  .admin-customer-list {
+    display: grid;
+    gap: 0.75rem;
+  }
+
+  .admin-customer {
+    display: grid;
+    grid-template-columns: 1fr auto;
+    gap: 0.6rem 1.2rem;
+    align-items: center;
+    padding: 1rem 1.1rem;
+    border-radius: 18px;
+    background: rgba(255, 255, 255, 0.72);
+    border: 1px solid rgba(112, 85, 66, 0.1);
+    transition: box-shadow 0.18s;
+  }
+
+  .admin-customer:hover {
+    box-shadow: 0 6px 18px rgba(53, 30, 20, 0.08);
+  }
+
+  .admin-customer__info {
+    display: grid;
+    gap: 0.18rem;
+  }
+
+  .admin-customer__name {
+    font-family: "Bricolage Grotesque", "Be Vietnam Pro", sans-serif;
+    font-size: 1rem;
+    font-weight: 700;
+    color: var(--text-main);
+    margin: 0;
+  }
+
+  .admin-customer__email {
+    font-size: 0.88rem;
+    color: var(--text-muted);
+  }
+
+  .admin-customer__meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem 1.1rem;
+    margin-top: 0.35rem;
+    font-size: 0.85rem;
+    color: var(--text-muted);
+  }
+
+  .admin-customer__meta span {
+    display: flex;
+    align-items: center;
+    gap: 0.3rem;
+  }
+
+  .admin-customer__meta strong {
+    color: var(--text-main);
+  }
+
+  .admin-badge {
+    display: inline-flex;
+    padding: 0.38rem 0.75rem;
+    border-radius: 999px;
+    font-size: 0.78rem;
+    font-weight: 800;
+    white-space: nowrap;
+  }
+
+  .admin-badge--registered {
+    color: #1a6e3c;
+    background: rgba(34, 197, 94, 0.12);
+  }
+
+  .admin-badge--guest {
+    color: var(--brand-red);
+    background: rgba(255, 106, 19, 0.1);
+  }
+
+  .admin-empty {
+    color: var(--text-muted);
+    line-height: 1.6;
+    margin-top: 0.7rem;
+  }
+
+  @media (max-width: 980px) {
+    .admin-hero__stats {
+      grid-template-columns: 1fr;
+    }
+
+    .admin-customer {
+      grid-template-columns: 1fr;
+    }
+  }
+</style>
+{% endblock %}
+
 {% block content %}
-<h1>Customer Accounts</h1>
-<table>
-  {% for c in customers %}
-  <tr>
-    <td>{{ c.customer_name }}</td>
-    <td>{{ c.customer_email }}</td>
-    <<td>{{ c.customer_phone }}</td>
-  </tr>
-  {% endfor %}
-</table>
+<div class="admin-customers">
+
+  <section class="admin-panel section-panel">
+    <div class="admin-hero__grid">
+      <div>
+        <p class="eyebrow">Customer management</p>
+        <h1 class="section-title">Customer accounts</h1>
+        <p class="section-copy">
+          All registered and guest customers are listed here. Registered accounts have a profile on the system.
+          Guest customers have placed at least one order without signing up.
+        </p>
+      </div>
+      <div class="admin-hero__stats">
+        <article class="admin-stat">
+          <strong>{{ customers|length }}</strong>
+          <span>Total customers{% if search_query %} matching "{{ search_query }}"{% endif %}</span>
+        </article>
+        <article class="admin-stat">
+          <strong>{{ registered_count }}</strong>
+          <span>Registered accounts</span>
+        </article>
+        <article class="admin-stat">
+          <strong>{{ guest_count }}</strong>
+          <span>Guest orderers</span>
+        </article>
+      </div>
+    </div>
+  </section>
+
+  <section class="admin-section">
+    <header class="admin-section__header">
+      <p class="eyebrow">All customers</p>
+      <h2>Customer directory</h2>
+      <p>Sorted alphabetically. Search by name or email address.</p>
+    </header>
+
+    <form class="admin-search-form" method="get" action="{{ url_for('admin.admin_customers') }}">
+      <input
+        type="search"
+        name="q"
+        value="{{ search_query }}"
+        placeholder="Search by name or email…"
+        autocomplete="off"
+      />
+      <button type="submit" class="button button--secondary">Search</button>
+      {% if search_query %}
+        <a href="{{ url_for('admin.admin_customers') }}" class="button button--secondary">Clear</a>
+      {% endif %}
+    </form>
+
+    {% if not customers %}
+      <p class="admin-empty">
+        {% if search_query %}
+          No customers found matching "{{ search_query }}".
+        {% else %}
+          No customers yet.
+        {% endif %}
+      </p>
+    {% else %}
+      <div class="admin-customer-list">
+        {% for c in customers %}
+          <article class="admin-customer">
+            <div class="admin-customer__info">
+              <h3 class="admin-customer__name">{{ c.name }}</h3>
+              <span class="admin-customer__email">{{ c.email }}</span>
+              <div class="admin-customer__meta">
+                <span>
+                  Orders: <strong>{{ c.order_count }}</strong>
+                </span>
+                <span>
+                  Spent: <strong>{{ c.total_spent }}</strong>
+                </span>
+                {% if c.joined != "—" %}
+                  <span>
+                    Joined: <strong>{{ c.joined }}</strong>
+                  </span>
+                {% endif %}
+              </div>
+            </div>
+            <span class="admin-badge admin-badge--{{ c.type }}">
+              {{ "Registered" if c.type == "registered" else "Guest" }}
+            </span>
+          </article>
+        {% endfor %}
+      </div>
+    {% endif %}
+  </section>
+
+</div>
 {% endblock %}

--- a/templates/admin/customers.html
+++ b/templates/admin/customers.html
@@ -52,6 +52,28 @@
     box-shadow: 0 22px 40px rgba(53, 30, 20, 0.12);
   }
 
+  .admin-stat--link.is-active {
+    border-color: rgba(255, 106, 19, 0.5);
+    background:
+      linear-gradient(180deg, rgba(255, 245, 232, 0.98), rgba(255, 231, 204, 0.96)),
+      #fff7ed;
+    box-shadow: 0 18px 34px rgba(255, 106, 19, 0.14);
+  }
+
+  .admin-stat--link.is-active::after {
+    content: "Active filter";
+    position: absolute;
+    top: 0.65rem;
+    right: 0.8rem;
+    border-radius: 999px;
+    padding: 0.2rem 0.48rem;
+    background: rgba(255, 106, 19, 0.12);
+    color: var(--brand-red);
+    font-size: 0.68rem;
+    font-weight: 800;
+    text-transform: uppercase;
+  }
+
   .admin-stat--link:focus-visible {
     outline: 2px solid rgba(255, 106, 19, 0.28);
     outline-offset: 2px;
@@ -306,15 +328,15 @@
         </p>
       </div>
       <div class="admin-hero__stats">
-        <a class="admin-stat admin-stat--link" href="{{ url_for('admin.admin_customers') }}">
+        <a class="admin-stat admin-stat--link {% if account_type == 'all' %}is-active{% endif %}" href="{{ url_for('admin.admin_customers') }}">
           <strong>{{ customers|length }}</strong>
           <span>Total customers{% if search_query %} matching "{{ search_query }}"{% endif %}</span>
         </a>
-        <a class="admin-stat admin-stat--link" href="{{ url_for('admin.admin_customers', account_type='registered') }}">
+        <a class="admin-stat admin-stat--link {% if account_type == 'registered' %}is-active{% endif %}" href="{{ url_for('admin.admin_customers', account_type='registered') }}">
           <strong>{{ registered_count }}</strong>
           <span>Registered accounts</span>
         </a>
-        <a class="admin-stat admin-stat--link" href="{{ url_for('admin.admin_customers', account_type='guest') }}">
+        <a class="admin-stat admin-stat--link {% if account_type == 'guest' %}is-active{% endif %}" href="{{ url_for('admin.admin_customers', account_type='guest') }}">
           <strong>{{ guest_count }}</strong>
           <span>Guest orderers</span>
         </a>

--- a/templates/admin/customers.html
+++ b/templates/admin/customers.html
@@ -453,7 +453,8 @@
               {{ "Registered" if c.type == "registered" else "Guest" }}
             </span>
             <div class="admin-customer__actions">
-              <a class="admin-row-action" href="{{ url_for('admin.admin_customers', q=c.email) }}">View orders</a>
+              <a class="admin-row-action" href="{{ c.profile_href }}">View profile</a>
+              <a class="admin-row-action" href="{{ url_for('admin.admin_orders', q=c.email) }}">View orders</a>
               <a class="admin-row-action" href="mailto:{{ c.email }}">Email</a>
             </div>
           </article>

--- a/templates/admin/customers.html
+++ b/templates/admin/customers.html
@@ -1,0 +1,13 @@
+{% extends "base.html" %}
+{% block content %}
+<h1>Customer Accounts</h1>
+<table>
+  {% for c in customers %}
+  <tr>
+    <td>{{ c.customer_name }}</td>
+    <td>{{ c.customer_email }}</td>
+    <<td>{{ c.customer_phone }}</td>
+  </tr>
+  {% endfor %}
+</table>
+{% endblock %}

--- a/templates/admin/customers.html
+++ b/templates/admin/customers.html
@@ -38,6 +38,25 @@
     padding: 1.05rem 1.1rem;
   }
 
+  .admin-stat--link {
+    display: block;
+    text-decoration: none;
+    color: inherit;
+    transition: transform 0.18s ease, box-shadow 0.18s ease, border-color 0.18s ease;
+  }
+
+  .admin-stat--link:hover,
+  .admin-stat--link:focus-visible {
+    transform: translateY(-1px);
+    border-color: rgba(255, 106, 19, 0.28);
+    box-shadow: 0 22px 40px rgba(53, 30, 20, 0.12);
+  }
+
+  .admin-stat--link:focus-visible {
+    outline: 2px solid rgba(255, 106, 19, 0.28);
+    outline-offset: 2px;
+  }
+
   .admin-stat strong {
     display: block;
     font-family: "Bricolage Grotesque", "Be Vietnam Pro", sans-serif;
@@ -287,18 +306,18 @@
         </p>
       </div>
       <div class="admin-hero__stats">
-        <article class="admin-stat">
+        <a class="admin-stat admin-stat--link" href="{{ url_for('admin.admin_customers') }}">
           <strong>{{ customers|length }}</strong>
           <span>Total customers{% if search_query %} matching "{{ search_query }}"{% endif %}</span>
-        </article>
-        <article class="admin-stat">
+        </a>
+        <a class="admin-stat admin-stat--link" href="{{ url_for('admin.admin_customers', account_type='registered') }}">
           <strong>{{ registered_count }}</strong>
           <span>Registered accounts</span>
-        </article>
-        <article class="admin-stat">
+        </a>
+        <a class="admin-stat admin-stat--link" href="{{ url_for('admin.admin_customers', account_type='guest') }}">
           <strong>{{ guest_count }}</strong>
           <span>Guest orderers</span>
-        </article>
+        </a>
       </div>
     </div>
   </section>

--- a/templates/admin/customers.html
+++ b/templates/admin/customers.html
@@ -239,7 +239,7 @@
 
   .admin-customer {
     display: grid;
-    grid-template-columns: 1fr auto;
+    grid-template-columns: 1fr auto auto;
     gap: 0.5rem 0.9rem;
     align-items: center;
     padding: 0.78rem 0.9rem;
@@ -307,6 +307,36 @@
   .admin-badge--guest {
     color: var(--brand-red);
     background: rgba(255, 106, 19, 0.1);
+  }
+
+  .admin-customer__actions {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: flex-end;
+    gap: 0.4rem;
+  }
+
+  .admin-row-action {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 34px;
+    padding: 0 0.72rem;
+    border-radius: 999px;
+    border: 1px solid rgba(112, 85, 66, 0.16);
+    background: rgba(255, 255, 255, 0.62);
+    color: var(--text-main);
+    font-size: 0.78rem;
+    font-weight: 800;
+    text-decoration: none;
+    transition: border-color 0.18s ease, color 0.18s ease, background 0.18s ease;
+  }
+
+  .admin-row-action:hover,
+  .admin-row-action:focus-visible {
+    border-color: rgba(255, 106, 19, 0.34);
+    background: #fff;
+    color: var(--brand-red);
   }
 
   .admin-empty {
@@ -422,6 +452,10 @@
             <span class="admin-badge admin-badge--{{ c.type }}">
               {{ "Registered" if c.type == "registered" else "Guest" }}
             </span>
+            <div class="admin-customer__actions">
+              <a class="admin-row-action" href="{{ url_for('admin.admin_customers', q=c.email) }}">View orders</a>
+              <a class="admin-row-action" href="mailto:{{ c.email }}">Email</a>
+            </div>
           </article>
         {% endfor %}
       </div>

--- a/templates/admin/customers.html
+++ b/templates/admin/customers.html
@@ -79,6 +79,7 @@
   /* Search */
   .admin-search-form {
     display: flex;
+    flex-wrap: wrap;
     gap: 0.65rem;
     align-items: center;
     margin-bottom: 1.2rem;
@@ -86,23 +87,94 @@
 
   .admin-search-form input[type="search"] {
     flex: 1;
-    padding: 0.65rem 1rem;
+    min-width: 220px;
+    padding: 0 1rem;
     border-radius: 999px;
     border: 1px solid rgba(112, 85, 66, 0.2);
-    background: rgba(255, 255, 255, 0.8);
+    background: rgba(255, 255, 255, 0.84);
+    box-shadow: 0 8px 18px rgba(53, 30, 20, 0.05);
     font-family: "Be Vietnam Pro", sans-serif;
     font-size: 0.95rem;
     color: var(--text-main);
     outline: none;
-    transition: border-color 0.18s;
+    transition: border-color 0.18s, box-shadow 0.18s, background 0.18s;
   }
 
   .admin-search-form input[type="search"]:focus {
     border-color: var(--brand-orange);
+    box-shadow: 0 0 0 3px rgba(255, 106, 19, 0.16);
+    background: #fff;
   }
 
-  .admin-search-form button {
+  .admin-search-form button,
+  .admin-search-form a {
     flex-shrink: 0;
+  }
+
+  .admin-search-form select {
+    padding: 0 2.4rem 0 1rem;
+    appearance: none;
+    -webkit-appearance: none;
+    background-image:
+      linear-gradient(45deg, transparent 50%, var(--brand-orange) 50%),
+      linear-gradient(135deg, var(--brand-orange) 50%, transparent 50%);
+    background-position:
+      calc(100% - 16px) calc(50% - 2px),
+      calc(100% - 10px) calc(50% - 2px);
+    background-size: 6px 6px, 6px 6px;
+    background-repeat: no-repeat;
+    border-radius: 999px;
+    border: 1px solid rgba(112, 85, 66, 0.2);
+    background-color: rgba(255, 255, 255, 0.84);
+    box-shadow: 0 8px 18px rgba(53, 30, 20, 0.05);
+    font-family: "Be Vietnam Pro", sans-serif;
+    font-size: 0.95rem;
+    color: var(--text-main);
+    outline: none;
+    transition: border-color 0.18s, box-shadow 0.18s, background-color 0.18s;
+  }
+
+  .admin-search-form select:focus {
+    border-color: var(--brand-orange);
+    box-shadow: 0 0 0 3px rgba(255, 106, 19, 0.16);
+    background-color: #fff;
+  }
+
+  .admin-search-form input[type="search"],
+  .admin-search-form select,
+  .admin-search-form .button {
+    min-height: 42px;
+    box-sizing: border-box;
+  }
+
+  .admin-search-form .button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0 1.1rem;
+    line-height: 1;
+    font-family: "Be Vietnam Pro", sans-serif;
+    font-size: 0.95rem;
+    font-weight: 700;
+    border-width: 1px;
+    box-shadow: 0 8px 18px rgba(53, 30, 20, 0.05);
+  }
+
+  .admin-search-form .button--secondary {
+    color: var(--text-main);
+    background: rgba(255, 255, 255, 0.84);
+    border-color: rgba(112, 85, 66, 0.2);
+  }
+
+  .admin-search-form .button--secondary:hover {
+    background: rgba(255, 255, 255, 0.95);
+    border-color: rgba(255, 106, 19, 0.35);
+    box-shadow: 0 10px 22px rgba(53, 30, 20, 0.1);
+  }
+
+  .admin-search-form .button--secondary:focus-visible {
+    outline: 2px solid rgba(255, 106, 19, 0.35);
+    outline-offset: 2px;
   }
 
   /* Customer rows */

--- a/templates/admin/customers.html
+++ b/templates/admin/customers.html
@@ -246,8 +246,13 @@
         placeholder="Search by name or email…"
         autocomplete="off"
       />
+      <select name="account_type" aria-label="Filter by account type">
+        <option value="all" {% if account_type == "all" %}selected{% endif %}>All accounts</option>
+        <option value="registered" {% if account_type == "registered" %}selected{% endif %}>Registered only</option>
+        <option value="guest" {% if account_type == "guest" %}selected{% endif %}>Guest only</option>
+      </select>
       <button type="submit" class="button button--secondary">Search</button>
-      {% if search_query %}
+      {% if search_query or account_type != "all" %}
         <a href="{{ url_for('admin.admin_customers') }}" class="button button--secondary">Clear</a>
       {% endif %}
     </form>
@@ -255,7 +260,14 @@
     {% if not customers %}
       <p class="admin-empty">
         {% if search_query %}
-          No customers found matching "{{ search_query }}".
+          No customers found matching "{{ search_query }}"
+          {% if account_type == "registered" %}
+            for registered accounts
+          {% elif account_type == "guest" %}
+            for guest accounts
+          {% endif %}.
+        {% elif account_type != "all" %}
+          No {{ "registered" if account_type == "registered" else "guest" }} customers found.
         {% else %}
           No customers yet.
         {% endif %}

--- a/templates/admin/customers.html
+++ b/templates/admin/customers.html
@@ -6,18 +6,18 @@
 <style>
   .admin-customers {
     display: grid;
-    gap: 1.4rem;
+    gap: 1rem;
   }
 
   .admin-panel {
-    padding: clamp(1.2rem, 3vw, 2rem);
+    padding: clamp(1rem, 2.4vw, 1.45rem);
   }
 
   .admin-hero__grid {
     position: relative;
     z-index: 1;
     display: grid;
-    gap: 1rem;
+    gap: 0.8rem;
   }
 
   .admin-hero__stats {
@@ -29,13 +29,13 @@
   .admin-stat {
     position: relative;
     overflow: hidden;
-    border-radius: 26px;
+    border-radius: 18px;
     border: 1px solid rgba(112, 85, 66, 0.12);
     background:
       linear-gradient(180deg, rgba(255, 252, 247, 0.98), rgba(248, 236, 220, 0.94)),
       #fff;
     box-shadow: 0 18px 36px rgba(53, 30, 20, 0.07);
-    padding: 1.05rem 1.1rem;
+    padding: 0.85rem 1rem;
   }
 
   .admin-stat--link {
@@ -60,7 +60,7 @@
   .admin-stat strong {
     display: block;
     font-family: "Bricolage Grotesque", "Be Vietnam Pro", sans-serif;
-    font-size: 1.4rem;
+    font-size: 1.25rem;
   }
 
   .admin-stat span {
@@ -71,23 +71,23 @@
   .admin-section {
     position: relative;
     overflow: hidden;
-    border-radius: 26px;
+    border-radius: 18px;
     border: 1px solid rgba(112, 85, 66, 0.12);
     background:
       linear-gradient(180deg, rgba(255, 252, 247, 0.98), rgba(248, 236, 220, 0.94)),
       #fff;
     box-shadow: 0 18px 36px rgba(53, 30, 20, 0.07);
-    padding: 1.4rem 1.5rem;
+    padding: 1rem 1.1rem;
   }
 
   .admin-section__header {
-    margin-bottom: 1.2rem;
+    margin-bottom: 0.85rem;
   }
 
   .admin-section__header h2 {
     margin: 0.24rem 0 0;
     font-family: "Bricolage Grotesque", "Be Vietnam Pro", sans-serif;
-    font-size: clamp(1.3rem, 2vw, 1.8rem);
+    font-size: clamp(1.15rem, 1.7vw, 1.45rem);
   }
 
   .admin-section__header p {
@@ -99,9 +99,9 @@
   .admin-search-form {
     display: flex;
     flex-wrap: wrap;
-    gap: 0.65rem;
+    gap: 0.55rem;
     align-items: center;
-    margin-bottom: 1.2rem;
+    margin-bottom: 0.85rem;
   }
 
   .admin-search-form input[type="search"] {
@@ -199,16 +199,16 @@
   /* Customer rows */
   .admin-customer-list {
     display: grid;
-    gap: 0.75rem;
+    gap: 0.55rem;
   }
 
   .admin-customer {
     display: grid;
     grid-template-columns: 1fr auto;
-    gap: 0.6rem 1.2rem;
+    gap: 0.5rem 0.9rem;
     align-items: center;
-    padding: 1rem 1.1rem;
-    border-radius: 18px;
+    padding: 0.78rem 0.9rem;
+    border-radius: 14px;
     background: rgba(255, 255, 255, 0.72);
     border: 1px solid rgba(112, 85, 66, 0.1);
     transition: box-shadow 0.18s;
@@ -239,8 +239,8 @@
   .admin-customer__meta {
     display: flex;
     flex-wrap: wrap;
-    gap: 0.5rem 1.1rem;
-    margin-top: 0.35rem;
+    gap: 0.35rem 0.9rem;
+    margin-top: 0.25rem;
     font-size: 0.85rem;
     color: var(--text-muted);
   }
@@ -257,7 +257,7 @@
 
   .admin-badge {
     display: inline-flex;
-    padding: 0.38rem 0.75rem;
+    padding: 0.3rem 0.65rem;
     border-radius: 999px;
     font-size: 0.78rem;
     font-weight: 800;

--- a/templates/admin/dashboard.html
+++ b/templates/admin/dashboard.html
@@ -25,8 +25,35 @@
 
   .admin-dashboard__charts {
     display: grid;
-    grid-template-columns: repeat(3, minmax(0, 1fr));
+    grid-template-columns: 1.25fr 1fr 0.8fr;
     gap: 0.85rem;
+  }
+
+  .admin-chart-card {
+    padding: 0;
+    overflow: hidden;
+  }
+
+  .admin-chart-card__head {
+    display: flex;
+    justify-content: space-between;
+    gap: 1rem;
+    align-items: flex-start;
+    padding: 1rem 1.1rem 0;
+  }
+
+  .admin-chart-card__head h2 {
+    margin: 0.2rem 0 0;
+  }
+
+  .admin-chart-total {
+    border-radius: 999px;
+    background: rgba(255, 106, 19, 0.1);
+    color: var(--brand-red);
+    font-size: 0.78rem;
+    font-weight: 900;
+    padding: 0.42rem 0.7rem;
+    white-space: nowrap;
   }
 
   .admin-card {
@@ -90,42 +117,65 @@
   }
 
   .plot {
+    position: relative;
     display: flex;
     align-items: end;
-    gap: 0.42rem;
-    min-height: 190px;
-    margin-top: 1rem;
-    padding: 0.7rem 0.2rem 0;
-    border-bottom: 1px solid rgba(112, 85, 66, 0.2);
+    gap: 0.5rem;
+    min-height: 230px;
+    margin-top: 0.5rem;
+    padding: 1rem 1rem 1.1rem;
+    background:
+      linear-gradient(rgba(112, 85, 66, 0.08) 1px, transparent 1px),
+      linear-gradient(180deg, rgba(255, 255, 255, 0.6), rgba(255, 246, 235, 0.78));
+    background-size: 100% 25%;
+    border-top: 1px solid rgba(112, 85, 66, 0.08);
   }
 
   .plot-column {
     flex: 1;
     min-width: 24px;
-    display: grid;
-    align-content: end;
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-end;
     gap: 0.45rem;
     text-align: center;
   }
 
+  .plot-bar-wrap {
+    height: 150px;
+    display: flex;
+    align-items: flex-end;
+    justify-content: center;
+  }
+
   .plot-bar {
-    width: 100%;
+    width: min(100%, 34px);
     min-height: 8px;
-    border-radius: 999px 999px 4px 4px;
-    background: linear-gradient(180deg, var(--brand-gold), var(--brand-orange), var(--brand-red));
-    box-shadow: 0 10px 18px rgba(255, 106, 19, 0.18);
+    border-radius: 999px 999px 8px 8px;
+    background:
+      linear-gradient(180deg, rgba(255, 255, 255, 0.42), transparent 30%),
+      linear-gradient(180deg, #ffd873 0%, #ff6a13 50%, #9b3120 100%);
+    box-shadow: 0 12px 20px rgba(255, 106, 19, 0.2);
   }
 
   .plot-label {
     color: var(--text-muted);
-    font-size: 0.72rem;
+    font-size: 0.7rem;
+    line-height: 1.2;
     overflow-wrap: anywhere;
   }
 
   .plot-value {
     color: var(--text-main);
-    font-size: 0.76rem;
+    font-size: 0.74rem;
     font-weight: 800;
+    min-height: 1.2rem;
+  }
+
+  .plot-orders {
+    color: var(--text-muted);
+    font-size: 0.68rem;
   }
 
   .recent-order {
@@ -195,15 +245,23 @@
   </section>
 
   <section class="admin-dashboard__charts">
-    <article class="admin-card">
-      <p class="eyebrow">Daily income</p>
-      <h2>By day</h2>
+    <article class="admin-card admin-chart-card">
+      <div class="admin-chart-card__head">
+        <div>
+          <p class="eyebrow">Daily income</p>
+          <h2>By day</h2>
+        </div>
+        <span class="admin-chart-total">{{ daily_report|length }} days</span>
+      </div>
       <div class="plot">
         {% for row in daily_report %}
-          <div class="plot-column">
+          <div class="plot-column" title="{{ row.period }} · {{ row.revenue_display }} · {{ row.order_count }} orders">
             <span class="plot-value">{{ row.revenue_display }}</span>
-            <div class="plot-bar" style="height: {{ row.bar_height }}%"></div>
+            <div class="plot-bar-wrap">
+              <div class="plot-bar" style="height: {{ row.bar_height }}%"></div>
+            </div>
             <span class="plot-label">{{ row.period }}</span>
+            <span class="plot-orders">{{ row.order_count }} orders</span>
           </div>
         {% else %}
           <p>No daily income yet.</p>
@@ -211,15 +269,23 @@
       </div>
     </article>
 
-    <article class="admin-card">
-      <p class="eyebrow">Monthly income</p>
-      <h2>By month</h2>
+    <article class="admin-card admin-chart-card">
+      <div class="admin-chart-card__head">
+        <div>
+          <p class="eyebrow">Monthly income</p>
+          <h2>By month</h2>
+        </div>
+        <span class="admin-chart-total">{{ monthly_report|length }} months</span>
+      </div>
       <div class="plot">
         {% for row in monthly_report %}
-          <div class="plot-column">
+          <div class="plot-column" title="{{ row.period }} · {{ row.revenue_display }} · {{ row.order_count }} orders">
             <span class="plot-value">{{ row.revenue_display }}</span>
-            <div class="plot-bar" style="height: {{ row.bar_height }}%"></div>
+            <div class="plot-bar-wrap">
+              <div class="plot-bar" style="height: {{ row.bar_height }}%"></div>
+            </div>
             <span class="plot-label">{{ row.period }}</span>
+            <span class="plot-orders">{{ row.order_count }} orders</span>
           </div>
         {% else %}
           <p>No monthly income yet.</p>
@@ -227,15 +293,23 @@
       </div>
     </article>
 
-    <article class="admin-card">
-      <p class="eyebrow">Yearly income</p>
-      <h2>By year</h2>
+    <article class="admin-card admin-chart-card">
+      <div class="admin-chart-card__head">
+        <div>
+          <p class="eyebrow">Yearly income</p>
+          <h2>By year</h2>
+        </div>
+        <span class="admin-chart-total">{{ yearly_report|length }} years</span>
+      </div>
       <div class="plot">
         {% for row in yearly_report %}
-          <div class="plot-column">
+          <div class="plot-column" title="{{ row.period }} · {{ row.revenue_display }} · {{ row.order_count }} orders">
             <span class="plot-value">{{ row.revenue_display }}</span>
-            <div class="plot-bar" style="height: {{ row.bar_height }}%"></div>
+            <div class="plot-bar-wrap">
+              <div class="plot-bar" style="height: {{ row.bar_height }}%"></div>
+            </div>
             <span class="plot-label">{{ row.period }}</span>
+            <span class="plot-orders">{{ row.order_count }} orders</span>
           </div>
         {% else %}
           <p>No yearly income yet.</p>

--- a/templates/admin/dashboard.html
+++ b/templates/admin/dashboard.html
@@ -23,6 +23,12 @@
     grid-template-columns: minmax(0, 1.2fr) minmax(320px, 0.8fr);
   }
 
+  .admin-dashboard__charts {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 0.85rem;
+  }
+
   .admin-card {
     border-radius: 18px;
     border: 1px solid rgba(112, 85, 66, 0.12);
@@ -83,6 +89,45 @@
     background: linear-gradient(90deg, var(--brand-orange), var(--brand-red));
   }
 
+  .plot {
+    display: flex;
+    align-items: end;
+    gap: 0.42rem;
+    min-height: 190px;
+    margin-top: 1rem;
+    padding: 0.7rem 0.2rem 0;
+    border-bottom: 1px solid rgba(112, 85, 66, 0.2);
+  }
+
+  .plot-column {
+    flex: 1;
+    min-width: 24px;
+    display: grid;
+    align-content: end;
+    gap: 0.45rem;
+    text-align: center;
+  }
+
+  .plot-bar {
+    width: 100%;
+    min-height: 8px;
+    border-radius: 999px 999px 4px 4px;
+    background: linear-gradient(180deg, var(--brand-gold), var(--brand-orange), var(--brand-red));
+    box-shadow: 0 10px 18px rgba(255, 106, 19, 0.18);
+  }
+
+  .plot-label {
+    color: var(--text-muted);
+    font-size: 0.72rem;
+    overflow-wrap: anywhere;
+  }
+
+  .plot-value {
+    color: var(--text-main);
+    font-size: 0.76rem;
+    font-weight: 800;
+  }
+
   .recent-order {
     display: grid;
     grid-template-columns: 1fr auto;
@@ -107,7 +152,8 @@
 
   @media (max-width: 980px) {
     .admin-dashboard__stats,
-    .admin-dashboard__grid {
+    .admin-dashboard__grid,
+    .admin-dashboard__charts {
       grid-template-columns: 1fr;
     }
   }
@@ -125,6 +171,7 @@
       <a class="button button--secondary" href="{{ url_for('admin.admin_orders') }}">View orders</a>
       <a class="button button--secondary" href="{{ url_for('admin.admin_customers') }}">Customers</a>
       <a class="button button--secondary" href="{{ url_for('admin.admin_menu') }}">Menu items</a>
+      <a class="button button--secondary" href="{{ url_for('admin.admin_vouchers') }}">Vouchers</a>
     </div>
   </section>
 
@@ -147,14 +194,64 @@
     </article>
   </section>
 
+  <section class="admin-dashboard__charts">
+    <article class="admin-card">
+      <p class="eyebrow">Daily income</p>
+      <h2>By day</h2>
+      <div class="plot">
+        {% for row in daily_report %}
+          <div class="plot-column">
+            <span class="plot-value">{{ row.revenue_display }}</span>
+            <div class="plot-bar" style="height: {{ row.bar_height }}%"></div>
+            <span class="plot-label">{{ row.period }}</span>
+          </div>
+        {% else %}
+          <p>No daily income yet.</p>
+        {% endfor %}
+      </div>
+    </article>
+
+    <article class="admin-card">
+      <p class="eyebrow">Monthly income</p>
+      <h2>By month</h2>
+      <div class="plot">
+        {% for row in monthly_report %}
+          <div class="plot-column">
+            <span class="plot-value">{{ row.revenue_display }}</span>
+            <div class="plot-bar" style="height: {{ row.bar_height }}%"></div>
+            <span class="plot-label">{{ row.period }}</span>
+          </div>
+        {% else %}
+          <p>No monthly income yet.</p>
+        {% endfor %}
+      </div>
+    </article>
+
+    <article class="admin-card">
+      <p class="eyebrow">Yearly income</p>
+      <h2>By year</h2>
+      <div class="plot">
+        {% for row in yearly_report %}
+          <div class="plot-column">
+            <span class="plot-value">{{ row.revenue_display }}</span>
+            <div class="plot-bar" style="height: {{ row.bar_height }}%"></div>
+            <span class="plot-label">{{ row.period }}</span>
+          </div>
+        {% else %}
+          <p>No yearly income yet.</p>
+        {% endfor %}
+      </div>
+    </article>
+  </section>
+
   <section class="admin-dashboard__grid">
     <article class="admin-card">
       <p class="eyebrow">Monthly income</p>
-      <h2>Revenue report</h2>
+      <h2>Revenue records</h2>
       <div class="report-list">
         {% for row in monthly_report %}
           <div class="report-row">
-            <strong>{{ row.month }}</strong>
+            <strong>{{ row.period }}</strong>
             <div class="report-bar"><span style="width: {{ row.bar_width }}%"></span></div>
             <span>{{ row.revenue_display }}</span>
           </div>

--- a/templates/admin/dashboard.html
+++ b/templates/admin/dashboard.html
@@ -1,0 +1,186 @@
+{% extends "base.html" %}
+
+{% block title %}Admin Dashboard | MCQ Vietnamese Street Food{% endblock %}
+
+{% block head %}
+<style>
+  .admin-dashboard {
+    display: grid;
+    gap: 1rem;
+  }
+
+  .admin-dashboard__grid,
+  .admin-dashboard__stats {
+    display: grid;
+    gap: 0.85rem;
+  }
+
+  .admin-dashboard__stats {
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+  }
+
+  .admin-dashboard__grid {
+    grid-template-columns: minmax(0, 1.2fr) minmax(320px, 0.8fr);
+  }
+
+  .admin-card {
+    border-radius: 18px;
+    border: 1px solid rgba(112, 85, 66, 0.12);
+    background: linear-gradient(180deg, rgba(255, 252, 247, 0.98), rgba(248, 236, 220, 0.94)), #fff;
+    box-shadow: 0 18px 36px rgba(53, 30, 20, 0.07);
+    padding: 1rem 1.1rem;
+  }
+
+  .admin-card h2,
+  .admin-card h3 {
+    margin: 0.2rem 0 0;
+    font-family: "Bricolage Grotesque", "Be Vietnam Pro", sans-serif;
+  }
+
+  .admin-stat strong {
+    display: block;
+    font-family: "Bricolage Grotesque", "Be Vietnam Pro", sans-serif;
+    font-size: 1.35rem;
+  }
+
+  .admin-stat span,
+  .admin-card p {
+    color: var(--text-muted);
+  }
+
+  .admin-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.55rem;
+    margin-top: 0.9rem;
+  }
+
+  .report-list,
+  .recent-list {
+    display: grid;
+    gap: 0.65rem;
+    margin-top: 0.9rem;
+  }
+
+  .report-row {
+    display: grid;
+    grid-template-columns: 90px 1fr 92px;
+    gap: 0.75rem;
+    align-items: center;
+  }
+
+  .report-bar {
+    height: 12px;
+    border-radius: 999px;
+    background: rgba(112, 85, 66, 0.12);
+    overflow: hidden;
+  }
+
+  .report-bar span {
+    display: block;
+    height: 100%;
+    border-radius: inherit;
+    background: linear-gradient(90deg, var(--brand-orange), var(--brand-red));
+  }
+
+  .recent-order {
+    display: grid;
+    grid-template-columns: 1fr auto;
+    gap: 0.45rem 0.8rem;
+    align-items: center;
+    padding: 0.72rem 0;
+    border-top: 1px solid rgba(112, 85, 66, 0.12);
+  }
+
+  .recent-order:first-child {
+    border-top: 0;
+  }
+
+  .recent-order strong {
+    display: block;
+  }
+
+  .recent-order span {
+    color: var(--text-muted);
+    font-size: 0.88rem;
+  }
+
+  @media (max-width: 980px) {
+    .admin-dashboard__stats,
+    .admin-dashboard__grid {
+      grid-template-columns: 1fr;
+    }
+  }
+</style>
+{% endblock %}
+
+{% block content %}
+<div class="admin-dashboard">
+  <section class="admin-card">
+    <p class="eyebrow">Admin overview</p>
+    <h1 class="section-title">Store operations dashboard</h1>
+    <p class="section-copy">Review orders, pickup status, customers, menu operations, and revenue reporting from one place.</p>
+    <div class="admin-actions">
+      <a class="button button--primary" href="{{ url_for('admin.admin_queue') }}">Open queue</a>
+      <a class="button button--secondary" href="{{ url_for('admin.admin_orders') }}">View orders</a>
+      <a class="button button--secondary" href="{{ url_for('admin.admin_customers') }}">Customers</a>
+      <a class="button button--secondary" href="{{ url_for('admin.admin_menu') }}">Menu items</a>
+    </div>
+  </section>
+
+  <section class="admin-dashboard__stats">
+    <article class="admin-card admin-stat">
+      <strong>{{ total_orders }}</strong>
+      <span>Total orders</span>
+    </article>
+    <article class="admin-card admin-stat">
+      <strong>{{ active_orders }}</strong>
+      <span>Active pickup orders</span>
+    </article>
+    <article class="admin-card admin-stat">
+      <strong>{{ completed_orders }}</strong>
+      <span>Completed orders</span>
+    </article>
+    <article class="admin-card admin-stat">
+      <strong>{{ revenue_display }}</strong>
+      <span>Total sales</span>
+    </article>
+  </section>
+
+  <section class="admin-dashboard__grid">
+    <article class="admin-card">
+      <p class="eyebrow">Monthly income</p>
+      <h2>Revenue report</h2>
+      <div class="report-list">
+        {% for row in monthly_report %}
+          <div class="report-row">
+            <strong>{{ row.month }}</strong>
+            <div class="report-bar"><span style="width: {{ row.bar_width }}%"></span></div>
+            <span>{{ row.revenue_display }}</span>
+          </div>
+        {% else %}
+          <p>No sales records yet.</p>
+        {% endfor %}
+      </div>
+    </article>
+
+    <article class="admin-card">
+      <p class="eyebrow">Recent activity</p>
+      <h2>Latest orders</h2>
+      <div class="recent-list">
+        {% for order in recent_orders %}
+          <div class="recent-order">
+            <div>
+              <strong>{{ order.order_number }}</strong>
+              <span>{{ order.customer_name }} · {{ order.pickup_label }}</span>
+            </div>
+            <a class="button button--secondary" href="{{ url_for('orders.order_detail', order_number=order.order_number) }}">Open</a>
+          </div>
+        {% else %}
+          <p>No orders yet.</p>
+        {% endfor %}
+      </div>
+    </article>
+  </section>
+</div>
+{% endblock %}

--- a/templates/admin/menu_manage.html
+++ b/templates/admin/menu_manage.html
@@ -1,0 +1,216 @@
+{% extends "base.html" %}
+
+{% block title %}Admin Menu Items | MCQ Vietnamese Street Food{% endblock %}
+
+{% block head %}
+<style>
+  .admin-menu {
+    display: grid;
+    gap: 1rem;
+  }
+
+  .admin-panel {
+    border-radius: 18px;
+    border: 1px solid rgba(112, 85, 66, 0.12);
+    background: linear-gradient(180deg, rgba(255, 252, 247, 0.98), rgba(248, 236, 220, 0.94)), #fff;
+    box-shadow: 0 18px 36px rgba(53, 30, 20, 0.07);
+    padding: 1rem 1.1rem;
+  }
+
+  .admin-menu-form,
+  .admin-menu-card {
+    display: grid;
+    gap: 0.65rem;
+  }
+
+  .admin-menu-form {
+    grid-template-columns: repeat(6, minmax(0, 1fr));
+    align-items: end;
+  }
+
+  .admin-field {
+    display: grid;
+    gap: 0.25rem;
+  }
+
+  .admin-field--wide {
+    grid-column: span 2;
+  }
+
+  .admin-field label {
+    color: var(--text-muted);
+    font-size: 0.78rem;
+    font-weight: 800;
+    text-transform: uppercase;
+  }
+
+  .admin-field input,
+  .admin-field select,
+  .admin-field textarea {
+    width: 100%;
+    border-radius: 12px;
+    border: 1px solid rgba(112, 85, 66, 0.18);
+    background: rgba(255, 255, 255, 0.84);
+    box-sizing: border-box;
+    color: var(--text-main);
+    font: inherit;
+    padding: 0.72rem 0.8rem;
+  }
+
+  .admin-check {
+    display: inline-flex;
+    gap: 0.4rem;
+    align-items: center;
+    color: var(--text-main);
+    font-weight: 800;
+  }
+
+  .admin-menu-list {
+    display: grid;
+    gap: 0.7rem;
+  }
+
+  .admin-menu-card {
+    border: 1px solid rgba(112, 85, 66, 0.1);
+    border-radius: 14px;
+    background: rgba(255, 255, 255, 0.72);
+    padding: 0.9rem;
+  }
+
+  .admin-menu-card__head {
+    display: flex;
+    justify-content: space-between;
+    gap: 0.75rem;
+  }
+
+  .admin-menu-card__head h3 {
+    margin: 0;
+    font-family: "Bricolage Grotesque", "Be Vietnam Pro", sans-serif;
+  }
+
+  .admin-badge {
+    align-self: start;
+    border-radius: 999px;
+    background: rgba(34, 197, 94, 0.12);
+    color: #1a6e3c;
+    font-size: 0.78rem;
+    font-weight: 800;
+    padding: 0.32rem 0.66rem;
+    white-space: nowrap;
+  }
+
+  .admin-badge.is-off {
+    background: rgba(255, 106, 19, 0.1);
+    color: var(--brand-red);
+  }
+
+  .admin-menu-card__actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+  }
+
+  @media (max-width: 980px) {
+    .admin-menu-form {
+      grid-template-columns: 1fr;
+    }
+
+    .admin-field--wide {
+      grid-column: auto;
+    }
+  }
+</style>
+{% endblock %}
+
+{% block content %}
+<div class="admin-menu">
+  <section class="admin-panel">
+    <p class="eyebrow">Menu management</p>
+    <h1 class="section-title">Menu items</h1>
+    <p class="section-copy">{{ items|length }} items · {{ available_count }} currently available. Add, edit, remove, and update prices, descriptions, ingredients, categories, and availability.</p>
+  </section>
+
+  <section class="admin-panel">
+    <p class="eyebrow">Add item</p>
+    <form class="admin-menu-form" method="post" action="{{ url_for('admin.admin_menu') }}">
+      <input type="hidden" name="action" value="add" />
+      <div class="admin-field">
+        <label>Name</label>
+        <input name="name" required />
+      </div>
+      <div class="admin-field">
+        <label>Category</label>
+        <select name="category_id">
+          {% for category in categories %}
+            <option value="{{ category.id }}">{{ category.title }}</option>
+          {% endfor %}
+        </select>
+      </div>
+      <div class="admin-field">
+        <label>Price</label>
+        <input name="price" placeholder="$15" />
+      </div>
+      <div class="admin-field admin-field--wide">
+        <label>Description</label>
+        <input name="summary" />
+      </div>
+      <div class="admin-field">
+        <label>Ingredients</label>
+        <input name="ingredients" placeholder="Rice noodles, beef broth" />
+      </div>
+      <label class="admin-check"><input type="checkbox" name="available" checked /> Available</label>
+      <button class="button button--primary" type="submit">Add item</button>
+    </form>
+  </section>
+
+  <section class="admin-panel">
+    <p class="eyebrow">Edit catalog</p>
+    <div class="admin-menu-list">
+      {% for item in items %}
+        <article class="admin-menu-card">
+          <div class="admin-menu-card__head">
+            <div>
+              <h3>{{ item.name }}</h3>
+              <p>{{ item.category_title }} · {{ item.price }}</p>
+            </div>
+            <span class="admin-badge {% if not item.available %}is-off{% endif %}">
+              {{ "Available" if item.available else "Unavailable" }}
+            </span>
+          </div>
+          <form class="admin-menu-form" method="post" action="{{ url_for('admin.admin_menu') }}">
+            <input type="hidden" name="action" value="edit" />
+            <input type="hidden" name="item_id" value="{{ item.id }}" />
+            <div class="admin-field">
+              <label>Name</label>
+              <input name="name" value="{{ item.name }}" required />
+            </div>
+            <div class="admin-field">
+              <label>Price</label>
+              <input name="price" value="{{ item.price }}" />
+            </div>
+            <div class="admin-field admin-field--wide">
+              <label>Description</label>
+              <input name="summary" value="{{ item.summary }}" />
+            </div>
+            <div class="admin-field admin-field--wide">
+              <label>Ingredients</label>
+              <input name="ingredients" value="{{ item.ingredients }}" />
+            </div>
+            <div class="admin-field">
+              <label>Image path</label>
+              <input name="image" value="{{ item.image }}" />
+            </div>
+            <label class="admin-check"><input type="checkbox" name="available" {% if item.available %}checked{% endif %} /> Available</label>
+            <button class="button button--secondary" type="submit">Save</button>
+          </form>
+          <form class="admin-menu-card__actions" method="post" action="{{ url_for('admin.admin_menu') }}">
+            <input type="hidden" name="action" value="delete" />
+            <input type="hidden" name="item_id" value="{{ item.id }}" />
+            <button class="button button--secondary" type="submit">Remove</button>
+          </form>
+        </article>
+      {% endfor %}
+    </div>
+  </section>
+</div>
+{% endblock %}

--- a/templates/admin/menu_manage.html
+++ b/templates/admin/menu_manage.html
@@ -70,6 +70,33 @@
     gap: 0.7rem;
   }
 
+  .admin-catalog-tools {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.6rem;
+    align-items: center;
+    margin: 0.8rem 0;
+  }
+
+  .admin-catalog-tools input {
+    flex: 1;
+    min-width: 240px;
+    min-height: 42px;
+    border-radius: 999px;
+    border: 1px solid rgba(112, 85, 66, 0.18);
+    background: rgba(255, 255, 255, 0.84);
+    box-sizing: border-box;
+    color: var(--text-main);
+    font: inherit;
+    padding: 0 1rem;
+  }
+
+  .admin-catalog-count {
+    color: var(--text-muted);
+    font-size: 0.9rem;
+    font-weight: 700;
+  }
+
   .admin-menu-card {
     border: 1px solid rgba(112, 85, 66, 0.1);
     border-radius: 14px;
@@ -86,6 +113,21 @@
   .admin-menu-card__head h3 {
     margin: 0;
     font-family: "Bricolage Grotesque", "Be Vietnam Pro", sans-serif;
+  }
+
+  .admin-menu-card__preview {
+    display: grid;
+    grid-template-columns: 104px 1fr;
+    gap: 0.75rem;
+    align-items: center;
+  }
+
+  .admin-menu-card__preview img {
+    width: 104px;
+    aspect-ratio: 4 / 3;
+    border-radius: 12px;
+    object-fit: cover;
+    background: rgba(112, 85, 66, 0.1);
   }
 
   .admin-badge {
@@ -158,6 +200,10 @@
         <label>Ingredients</label>
         <input name="ingredients" placeholder="Rice noodles, beef broth" />
       </div>
+      <div class="admin-field">
+        <label>Image path</label>
+        <input name="image" placeholder="images/menu/items/example.jpg" />
+      </div>
       <label class="admin-check"><input type="checkbox" name="available" checked /> Available</label>
       <button class="button button--primary" type="submit">Add item</button>
     </form>
@@ -165,13 +211,28 @@
 
   <section class="admin-panel">
     <p class="eyebrow">Edit catalog</p>
+    <div class="admin-catalog-tools">
+      <input id="catalog-search" type="search" placeholder="Search menu items by name, category, price, ingredients, or image path" autocomplete="off" />
+      <span class="admin-catalog-count" id="catalog-count">{{ items|length }} showing</span>
+    </div>
     <div class="admin-menu-list">
       {% for item in items %}
-        <article class="admin-menu-card">
+        <article
+          class="admin-menu-card"
+          data-catalog-item
+          data-search="{{ item.name }} {{ item.category_title }} {{ item.price }} {{ item.summary }} {{ item.ingredients }} {{ item.image }}"
+        >
           <div class="admin-menu-card__head">
-            <div>
-              <h3>{{ item.name }}</h3>
-              <p>{{ item.category_title }} · {{ item.price }}</p>
+            <div class="admin-menu-card__preview">
+              <img
+                src="{{ url_for('static', filename=item.image or 'images/menu/pho-classic.jpg') }}"
+                alt="{{ item.name }}"
+                data-image-preview
+              />
+              <div>
+                <h3>{{ item.name }}</h3>
+                <p>{{ item.category_title }} · {{ item.price }}</p>
+              </div>
             </div>
             <span class="admin-badge {% if not item.available %}is-off{% endif %}">
               {{ "Available" if item.available else "Unavailable" }}
@@ -198,7 +259,7 @@
             </div>
             <div class="admin-field">
               <label>Image path</label>
-              <input name="image" value="{{ item.image }}" />
+              <input name="image" value="{{ item.image }}" data-image-input />
             </div>
             <label class="admin-check"><input type="checkbox" name="available" {% if item.available %}checked{% endif %} /> Available</label>
             <button class="button button--secondary" type="submit">Save</button>
@@ -213,4 +274,41 @@
     </div>
   </section>
 </div>
+<script>
+  (() => {
+    const search = document.getElementById("catalog-search");
+    const count = document.getElementById("catalog-count");
+    const cards = Array.from(document.querySelectorAll("[data-catalog-item]"));
+    const staticBase = "{{ url_for('static', filename='') }}";
+    const fallback = "{{ url_for('static', filename='images/menu/pho-classic.jpg') }}";
+
+    function updateCount() {
+      const showing = cards.filter((card) => !card.hidden).length;
+      if (count) count.textContent = `${showing} showing`;
+    }
+
+    if (search) {
+      search.addEventListener("input", () => {
+        const q = search.value.trim().toLowerCase();
+        cards.forEach((card) => {
+          card.hidden = q.length > 0 && !card.dataset.search.toLowerCase().includes(q);
+        });
+        updateCount();
+      });
+    }
+
+    cards.forEach((card) => {
+      const input = card.querySelector("[data-image-input]");
+      const preview = card.querySelector("[data-image-preview]");
+      if (!input || !preview) return;
+      input.addEventListener("input", () => {
+        const value = input.value.trim();
+        preview.src = value ? staticBase + value : fallback;
+      });
+      preview.addEventListener("error", () => {
+        preview.src = fallback;
+      });
+    });
+  })();
+</script>
 {% endblock %}

--- a/templates/admin/menu_manage.html
+++ b/templates/admin/menu_manage.html
@@ -81,6 +81,14 @@
   .admin-catalog-tools input {
     flex: 1;
     min-width: 240px;
+  }
+
+  .admin-catalog-tools select {
+    min-width: 170px;
+  }
+
+  .admin-catalog-tools input,
+  .admin-catalog-tools select {
     min-height: 42px;
     border-radius: 999px;
     border: 1px solid rgba(112, 85, 66, 0.18);
@@ -211,15 +219,30 @@
 
   <section class="admin-panel">
     <p class="eyebrow">Edit catalog</p>
-    <div class="admin-catalog-tools">
+    <form class="admin-catalog-tools" id="catalog-filter-form">
       <input id="catalog-search" type="search" placeholder="Search menu items by name, category, price, ingredients, or image path" autocomplete="off" />
+      <select id="catalog-category" aria-label="Filter category">
+        <option value="">All categories</option>
+        {% for category in categories %}
+          <option value="{{ category.title|lower }}">{{ category.title }}</option>
+        {% endfor %}
+      </select>
+      <select id="catalog-availability" aria-label="Filter availability">
+        <option value="">All availability</option>
+        <option value="available">Available</option>
+        <option value="unavailable">Unavailable</option>
+      </select>
+      <button class="button button--secondary" type="submit">Apply</button>
+      <button class="button button--secondary" type="button" id="catalog-clear">Clear</button>
       <span class="admin-catalog-count" id="catalog-count">{{ items|length }} showing</span>
-    </div>
+    </form>
     <div class="admin-menu-list">
       {% for item in items %}
         <article
           class="admin-menu-card"
           data-catalog-item
+          data-category="{{ item.category_title|lower }}"
+          data-availability="{{ 'available' if item.available else 'unavailable' }}"
           data-search="{{ item.name }} {{ item.category_title }} {{ item.price }} {{ item.summary }} {{ item.ingredients }} {{ item.image }}"
         >
           <div class="admin-menu-card__head">
@@ -276,7 +299,11 @@
 </div>
 <script>
   (() => {
+    const form = document.getElementById("catalog-filter-form");
     const search = document.getElementById("catalog-search");
+    const category = document.getElementById("catalog-category");
+    const availability = document.getElementById("catalog-availability");
+    const clear = document.getElementById("catalog-clear");
     const count = document.getElementById("catalog-count");
     const cards = Array.from(document.querySelectorAll("[data-catalog-item]"));
     const staticBase = "{{ url_for('static', filename='') }}";
@@ -287,13 +314,38 @@
       if (count) count.textContent = `${showing} showing`;
     }
 
-    if (search) {
-      search.addEventListener("input", () => {
-        const q = search.value.trim().toLowerCase();
-        cards.forEach((card) => {
-          card.hidden = q.length > 0 && !card.dataset.search.toLowerCase().includes(q);
-        });
-        updateCount();
+    function applyFilters() {
+      const q = search ? search.value.trim().toLowerCase() : "";
+      const cat = category ? category.value : "";
+      const status = availability ? availability.value : "";
+      cards.forEach((card) => {
+        const matchesText = !q || card.dataset.search.toLowerCase().includes(q);
+        const matchesCategory = !cat || card.dataset.category === cat;
+        const matchesAvailability = !status || card.dataset.availability === status;
+        card.hidden = !(matchesText && matchesCategory && matchesAvailability);
+      });
+      updateCount();
+    }
+
+    if (form) {
+      form.addEventListener("submit", (event) => {
+        event.preventDefault();
+        applyFilters();
+      });
+    }
+
+    [search, category, availability].forEach((control) => {
+      if (!control) return;
+      control.addEventListener("input", applyFilters);
+      control.addEventListener("change", applyFilters);
+    });
+
+    if (clear) {
+      clear.addEventListener("click", () => {
+        if (search) search.value = "";
+        if (category) category.value = "";
+        if (availability) availability.value = "";
+        applyFilters();
       });
     }
 

--- a/templates/admin/order_list.html
+++ b/templates/admin/order_list.html
@@ -1,0 +1,130 @@
+{% extends "base.html" %}
+
+{% block title %}Admin Orders | MCQ Vietnamese Street Food{% endblock %}
+
+{% block head %}
+<style>
+  .admin-orders-page {
+    display: grid;
+    gap: 1rem;
+  }
+
+  .admin-panel {
+    border-radius: 18px;
+    border: 1px solid rgba(112, 85, 66, 0.12);
+    background: linear-gradient(180deg, rgba(255, 252, 247, 0.98), rgba(248, 236, 220, 0.94)), #fff;
+    box-shadow: 0 18px 36px rgba(53, 30, 20, 0.07);
+    padding: 1rem 1.1rem;
+  }
+
+  .admin-order-filters {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.55rem;
+    margin-top: 0.9rem;
+  }
+
+  .admin-order-filters input,
+  .admin-order-filters select {
+    min-height: 42px;
+    border-radius: 999px;
+    border: 1px solid rgba(112, 85, 66, 0.2);
+    background: rgba(255, 255, 255, 0.84);
+    padding: 0 1rem;
+    font: inherit;
+  }
+
+  .admin-order-filters input {
+    flex: 1;
+    min-width: 220px;
+  }
+
+  .admin-order-table {
+    display: grid;
+    gap: 0.55rem;
+  }
+
+  .admin-order-row {
+    display: grid;
+    grid-template-columns: 1fr auto auto;
+    gap: 0.7rem;
+    align-items: center;
+    border: 1px solid rgba(112, 85, 66, 0.1);
+    border-radius: 14px;
+    background: rgba(255, 255, 255, 0.72);
+    padding: 0.78rem 0.9rem;
+  }
+
+  .admin-order-row strong,
+  .admin-order-row span {
+    display: block;
+  }
+
+  .admin-order-row span {
+    color: var(--text-muted);
+    font-size: 0.88rem;
+  }
+
+  .admin-badge {
+    border-radius: 999px;
+    background: rgba(255, 106, 19, 0.1);
+    color: var(--brand-red);
+    font-size: 0.78rem;
+    font-weight: 800;
+    padding: 0.32rem 0.66rem;
+    white-space: nowrap;
+  }
+
+  @media (max-width: 860px) {
+    .admin-order-row {
+      grid-template-columns: 1fr;
+    }
+  }
+</style>
+{% endblock %}
+
+{% block content %}
+<div class="admin-orders-page">
+  <section class="admin-panel">
+    <p class="eyebrow">Customer orders</p>
+    <h1 class="section-title">All orders</h1>
+    <p class="section-copy">Search customer orders, track pickup timing, and open each order for status management.</p>
+    <form class="admin-order-filters" method="get" action="{{ url_for('admin.admin_orders') }}">
+      <input type="search" name="q" value="{{ filters.q }}" placeholder="Search order, name, or email" />
+      <select name="status" aria-label="Filter status">
+        <option value="">All statuses</option>
+        {% for status in available_statuses %}
+          <option value="{{ status }}" {% if filters.status == status %}selected{% endif %}>{{ status }}</option>
+        {% endfor %}
+      </select>
+      <select name="fulfillment" aria-label="Filter fulfillment">
+        <option value="">All pickup types</option>
+        {% for item in fulfillment_types %}
+          <option value="{{ item }}" {% if filters.fulfillment == item %}selected{% endif %}>{{ item|title }}</option>
+        {% endfor %}
+      </select>
+      <button class="button button--secondary" type="submit">Filter</button>
+      <a class="button button--secondary" href="{{ url_for('admin.admin_orders') }}">Clear</a>
+    </form>
+  </section>
+
+  <section class="admin-panel">
+    <p class="eyebrow">{{ orders|length }} orders · {{ total_display }}</p>
+    <div class="admin-order-table">
+      {% for order in orders %}
+        <article class="admin-order-row">
+          <div>
+            <strong>{{ order.order_number }}</strong>
+            <span>{{ order.customer_name }} · {{ order.pickup_label }}</span>
+            <span>{{ order.fulfillment_type|title }}{% if order.queue_display %} · {{ order.queue_display }}{% endif %}</span>
+          </div>
+          <span class="admin-badge">{{ order.order_status }}</span>
+          <a class="button button--primary" href="{{ url_for('orders.order_detail', order_number=order.order_number) }}">Open detail</a>
+        </article>
+      {% else %}
+        <p>No orders match the current filters.</p>
+      {% endfor %}
+    </div>
+  </section>
+</div>
+{% endblock %}

--- a/templates/admin/vouchers.html
+++ b/templates/admin/vouchers.html
@@ -45,10 +45,12 @@
   .voucher-card {
     position: relative;
     overflow: hidden;
-    min-height: 470px;
+    width: min(100%, 1120px);
+    aspect-ratio: 16 / 7;
+    min-height: auto;
     background: linear-gradient(135deg, #21a74a 0%, #0c8a43 100%);
     color: #18120d;
-    padding: 2.4rem;
+    padding: 3.4%;
     box-shadow: 0 26px 60px rgba(7, 89, 39, 0.28), 0 12px 28px rgba(12, 138, 67, 0.22);
   }
 
@@ -56,14 +58,31 @@
     content: "";
     position: absolute;
     inset: auto auto 0 0;
-    width: 220px;
-    height: 260px;
+    width: 18%;
+    height: 42%;
     background:
-      radial-gradient(circle at 30% 22%, #ef4444 0 9px, transparent 10px),
-      radial-gradient(circle at 58% 20%, #facc15 0 11px, transparent 12px),
-      radial-gradient(circle at 42% 36%, #22c55e 0 15px, transparent 16px),
+      radial-gradient(circle at 30% 22%, #ef4444 0 7%, transparent 8%),
+      radial-gradient(circle at 58% 20%, #facc15 0 8%, transparent 9%),
+      radial-gradient(circle at 42% 36%, #22c55e 0 11%, transparent 12%),
       linear-gradient(145deg, #0f8b54, #075f3d);
-    border-radius: 0 90px 0 0;
+    border-radius: 0 50% 0 0;
+    opacity: 0.95;
+    pointer-events: none;
+  }
+
+  .voucher-card::after {
+    content: "";
+    position: absolute;
+    left: 1.5%;
+    top: 18%;
+    width: 18%;
+    height: 34%;
+    background:
+      radial-gradient(circle at 20% 65%, #f97316 0 12%, transparent 13%),
+      radial-gradient(circle at 42% 42%, #ef4444 0 10%, transparent 11%),
+      radial-gradient(circle at 62% 25%, #fde047 0 9%, transparent 10%),
+      radial-gradient(circle at 70% 58%, #22c55e 0 11%, transparent 12%);
+    filter: drop-shadow(0 18px 18px rgba(3, 66, 34, 0.25));
     opacity: 0.95;
     pointer-events: none;
   }
@@ -72,13 +91,15 @@
     position: relative;
     z-index: 1;
     display: grid;
-    grid-template-columns: minmax(0, 1.05fr) 2px minmax(0, 0.95fr);
-    gap: 1.7rem;
-    min-height: 330px;
-    margin-left: clamp(0rem, 8vw, 3.8rem);
-    padding: clamp(1.1rem, 3vw, 1.7rem);
-    background: #f7f1e9;
-    box-shadow: 12px 12px 0 rgba(2, 92, 43, 0.35), 0 18px 42px rgba(42, 22, 11, 0.18);
+    grid-template-columns: minmax(0, 1.02fr) 6px minmax(0, 0.98fr);
+    gap: 3%;
+    height: 74%;
+    margin-left: 12%;
+    padding: 2.9% 3.2%;
+    background:
+      linear-gradient(90deg, rgba(255, 255, 255, 0.94), rgba(255, 248, 238, 0.98)),
+      #f7f1e9;
+    box-shadow: 10px 10px 0 rgba(2, 92, 43, 0.35), 0 18px 42px rgba(42, 22, 11, 0.18);
   }
 
   .voucher-divider {
@@ -90,6 +111,15 @@
     display: grid;
     align-content: center;
     text-align: center;
+    min-width: 0;
+  }
+
+  .voucher-left {
+    gap: 0.7rem;
+  }
+
+  .voucher-right {
+    gap: 0.35rem;
   }
 
   .voucher-brand,
@@ -147,10 +177,10 @@
   }
 
   .voucher-brand img {
-    width: 138px;
-    height: 74px;
+    width: min(38%, 150px);
+    height: auto;
     border-radius: 0;
-    object-fit: cover;
+    object-fit: contain;
   }
 
   .voucher-brand h2 {
@@ -164,7 +194,7 @@
     z-index: 1;
     margin: 0 0 0.55rem;
     font-family: "Bebas Neue", "Bricolage Grotesque", sans-serif;
-    font-size: clamp(4.5rem, 13vw, 8.5rem);
+    font-size: clamp(4rem, 10vw, 9rem);
     line-height: 0.85;
     color: #d9160f;
     letter-spacing: 0.02em;
@@ -187,8 +217,8 @@
 
   .voucher-ideas {
     display: grid;
-    gap: 0.35rem;
-    margin: 0.8rem 0 0;
+    gap: 0.28rem;
+    margin: 0.45rem 0 0;
     text-align: left;
   }
 
@@ -196,8 +226,8 @@
     border-radius: 999px;
     background: rgba(217, 22, 15, 0.08);
     border: 1px solid rgba(217, 22, 15, 0.12);
-    padding: 0.42rem 0.65rem;
-    font-size: 0.82rem;
+    padding: 0.32rem 0.58rem;
+    font-size: clamp(0.68rem, 0.95vw, 0.82rem);
   }
 
   .voucher-description {
@@ -205,7 +235,8 @@
     z-index: 1;
     color: #24150c;
     line-height: 1.55;
-    margin: 0.8rem 0;
+    margin: 0.35rem 0;
+    font-size: clamp(0.74rem, 1vw, 0.94rem);
   }
 
   .voucher-idea strong {
@@ -214,11 +245,12 @@
   }
 
   .voucher-title {
-    margin: 0.4rem 0;
+    margin: 0;
     color: #d9160f;
     font-weight: 900;
     letter-spacing: 0.22em;
     text-transform: uppercase;
+    font-size: clamp(1.25rem, 2.1vw, 2.15rem);
   }
 
   .voucher-subtitle {
@@ -226,6 +258,8 @@
     font-weight: 900;
     letter-spacing: 0.18em;
     text-transform: uppercase;
+    font-size: clamp(0.78rem, 1.15vw, 1.05rem);
+    margin: 0;
   }
 
   .voucher-terms-title,
@@ -236,18 +270,29 @@
     text-transform: uppercase;
   }
 
+  .voucher-terms-title {
+    font-size: clamp(1.1rem, 1.8vw, 1.7rem);
+    margin: 0.2rem 0;
+  }
+
   .voucher-terms {
     white-space: pre-line;
-    line-height: 1.45;
-    margin: 0.8rem 0 1rem;
+    line-height: 1.35;
+    margin: 0.1rem 0;
+    font-size: clamp(0.72rem, 0.95vw, 0.9rem);
+  }
+
+  .voucher-expiry {
+    margin: 0.3rem 0 0;
+    font-size: clamp(0.86rem, 1.2vw, 1.1rem);
   }
 
   .voucher-footer {
     position: relative;
     z-index: 1;
-    margin: 1.6rem 0 0 clamp(0rem, 8vw, 3.8rem);
+    margin: 3.2% 0 0 16%;
     color: #fff;
-    font-size: clamp(0.95rem, 2vw, 1.25rem);
+    font-size: clamp(0.86rem, 1.6vw, 1.25rem);
     font-style: italic;
     line-height: 1.35;
     white-space: pre-line;
@@ -256,7 +301,7 @@
   .voucher-print-actions {
     display: flex;
     justify-content: flex-end;
-    margin-top: 0.9rem;
+    margin-top: 1rem;
   }
 
   .voucher-list {
@@ -284,16 +329,21 @@
     }
 
     .voucher-certificate {
-      grid-template-columns: 1fr;
+      grid-template-columns: minmax(0, 1fr) 4px minmax(0, 1fr);
       margin-left: 0;
     }
 
     .voucher-divider {
-      height: 2px;
+      height: auto;
     }
   }
 
   @media print {
+    @page {
+      size: landscape;
+      margin: 0;
+    }
+
     body * {
       visibility: hidden;
     }
@@ -307,7 +357,8 @@
       position: fixed;
       inset: 0;
       width: 100vw;
-      min-height: 100vh;
+      height: 100vh;
+      aspect-ratio: auto;
       border-radius: 0;
       box-shadow: none;
     }

--- a/templates/admin/vouchers.html
+++ b/templates/admin/vouchers.html
@@ -44,10 +44,10 @@
 
   .voucher-card {
     position: relative;
-    overflow: hidden;
+    overflow: visible;
     width: min(100%, 1120px);
-    aspect-ratio: 16 / 7;
-    min-height: auto;
+    aspect-ratio: 16 / 8.6;
+    min-height: 560px;
     background: linear-gradient(135deg, #21a74a 0%, #0c8a43 100%);
     color: #18120d;
     padding: 3.4%;
@@ -93,7 +93,7 @@
     display: grid;
     grid-template-columns: minmax(0, 1.02fr) 6px minmax(0, 0.98fr);
     gap: 3%;
-    height: 74%;
+    min-height: 390px;
     margin-left: 12%;
     padding: 2.9% 3.2%;
     background:
@@ -167,6 +167,13 @@
     display: grid;
     grid-template-columns: repeat(3, minmax(0, 1fr));
     gap: 0.55rem;
+  }
+
+  .voucher-value.is-selected {
+    background: linear-gradient(135deg, var(--brand-gold), var(--brand-orange));
+    color: #2a160b;
+    border-color: rgba(255, 106, 19, 0.6);
+    box-shadow: 0 10px 22px rgba(255, 106, 19, 0.18);
   }
 
   .voucher-brand {
@@ -300,6 +307,8 @@
 
   .voucher-print-actions {
     display: flex;
+    flex-wrap: wrap;
+    gap: 0.55rem;
     justify-content: flex-end;
     margin-top: 1rem;
   }
@@ -361,6 +370,7 @@
       aspect-ratio: auto;
       border-radius: 0;
       box-shadow: none;
+      overflow: hidden;
     }
 
     .voucher-print-actions {
@@ -380,47 +390,69 @@
 
   <section class="voucher-grid">
     <aside class="admin-panel">
-      <p class="eyebrow">Create value</p>
       <form class="voucher-create" method="post" action="{{ url_for('admin.admin_vouchers') }}">
-        <input type="hidden" name="action" value="create" />
+        {% if selected_voucher %}
+          <input type="hidden" name="voucher_id" value="{{ selected_voucher.id }}" />
+        {% endif %}
+        <p class="eyebrow">Live voucher editor</p>
+        <div class="voucher-field">
+          <label>Unique code</label>
+          <input name="code" value="{{ selected_voucher.code if selected_voucher else '' }}" placeholder="Auto-generated if left blank" />
+        </div>
+        <div class="voucher-field">
+          <label>Value</label>
+          <input id="voucher-value-input" name="value" value="{{ selected_voucher.value if selected_voucher else 150 }}" />
+        </div>
+        <div class="voucher-create-actions" aria-label="Voucher value presets">
+          {% for value in values %}
+            <button
+              class="voucher-value {% if selected_voucher and selected_voucher.value == value %}is-selected{% endif %}"
+              type="button"
+              data-voucher-value="{{ value }}"
+            >
+              ${{ value }}
+            </button>
+          {% endfor %}
+        </div>
         <div class="voucher-field">
           <label>Title</label>
-          <input name="label" value="$150 Catering Voucher" />
+          <input name="label" value="{{ selected_voucher.label if selected_voucher else '$150 Catering Voucher' }}" />
         </div>
         <div class="voucher-field">
           <label>Subtitle</label>
-          <input name="subtitle" value="For lucky customer in 12 days of Christmas giveaway" />
+          <input name="subtitle" value="{{ selected_voucher.subtitle if selected_voucher else 'For lucky customer in 12 days of Christmas giveaway' }}" />
         </div>
         <div class="voucher-field">
           <label>Valid until</label>
-          <input name="expires_at" value="13 May 2026" />
+          <input name="expires_at" value="{{ selected_voucher.expires_at if selected_voucher else '13 May 2026' }}" />
         </div>
         <div class="voucher-field">
           <label>Voucher description</label>
-          <textarea name="description">This voucher entitles the bearer to catering order value at MCQ Street Food Mirrabooka.</textarea>
+          <textarea name="description">{{ selected_voucher.description if selected_voucher else 'This voucher entitles the bearer to catering order value at MCQ Street Food Mirrabooka.' }}</textarea>
         </div>
         <div class="voucher-field">
           <label>Included items and quantities</label>
-          <textarea name="included_items">10 banh mi platters
+          <textarea name="included_items">{{ selected_voucher.included_items if selected_voucher else '10 banh mi platters
 12 Vietnamese iced coffees
 8 fresh juice cups
-1 catering pickup combo</textarea>
+1 catering pickup combo' }}</textarea>
         </div>
         <div class="voucher-field">
           <label>Terms and conditions</label>
-          <textarea name="terms">This gift certificate is not redeemable for cash.
-One time use only.</textarea>
+          <textarea name="terms">{{ selected_voucher.terms if selected_voucher else 'This gift certificate is not redeemable for cash.
+One time use only.' }}</textarea>
         </div>
         <div class="voucher-field">
           <label>Footer contact</label>
-          <textarea name="footer_note">Authorised by MCQ Vietnamese Street Food.
-For catering order requests, please contact: cateringorders@mcqinternational.com</textarea>
+          <textarea name="footer_note">{{ selected_voucher.footer_note if selected_voucher else 'Authorised by MCQ Vietnamese Street Food.
+For catering order requests, please contact: cateringorders@mcqinternational.com' }}</textarea>
         </div>
-        <div class="voucher-create-actions">
-          {% for value in values %}
-            <button class="voucher-value" type="submit" name="value" value="{{ value }}">${{ value }}</button>
-          {% endfor %}
-        </div>
+        <button class="button button--primary" type="submit" name="action" value="{% if selected_voucher %}update{% else %}create{% endif %}">
+          {% if selected_voucher %}Save voucher{% else %}Create voucher{% endif %}
+        </button>
+        {% if selected_voucher %}
+          <button class="button button--secondary" type="submit" name="action" value="create">Create as new voucher</button>
+        {% endif %}
       </form>
 
       <div class="voucher-list">
@@ -432,60 +464,16 @@ For catering order requests, please contact: cateringorders@mcqinternational.com
         {% endfor %}
       </div>
 
-      {% if selected_voucher %}
-        <form class="voucher-create" method="post" action="{{ url_for('admin.admin_vouchers') }}">
-          <input type="hidden" name="action" value="update" />
-          <input type="hidden" name="voucher_id" value="{{ selected_voucher.id }}" />
-          <p class="eyebrow">Edit selected voucher</p>
-          <div class="voucher-field">
-            <label>Unique code</label>
-            <input name="code" value="{{ selected_voucher.code }}" />
-          </div>
-          <div class="voucher-field">
-            <label>Value</label>
-            <input name="value" value="{{ selected_voucher.value }}" />
-          </div>
-          <div class="voucher-field">
-            <label>Title</label>
-            <input name="label" value="{{ selected_voucher.label }}" />
-          </div>
-          <div class="voucher-field">
-            <label>Subtitle</label>
-            <input name="subtitle" value="{{ selected_voucher.subtitle }}" />
-          </div>
-          <div class="voucher-field">
-            <label>Valid until</label>
-            <input name="expires_at" value="{{ selected_voucher.expires_at }}" />
-          </div>
-          <div class="voucher-field">
-            <label>Voucher description</label>
-            <textarea name="description">{{ selected_voucher.description }}</textarea>
-          </div>
-          <div class="voucher-field">
-            <label>Included items and quantities</label>
-            <textarea name="included_items">{{ selected_voucher.included_items }}</textarea>
-          </div>
-          <div class="voucher-field">
-            <label>Terms and conditions</label>
-            <textarea name="terms">{{ selected_voucher.terms }}</textarea>
-          </div>
-          <div class="voucher-field">
-            <label>Footer contact</label>
-            <textarea name="footer_note">{{ selected_voucher.footer_note }}</textarea>
-          </div>
-          <button class="button button--primary" type="submit">Save voucher</button>
-        </form>
-      {% endif %}
     </aside>
 
     {% if selected_voucher %}
       <article class="voucher-card">
         <div class="voucher-certificate">
           <div class="voucher-left">
-            <div class="voucher-value-display">{{ selected_voucher.value_display }}</div>
-            <h2 class="voucher-title">{{ selected_voucher.label }}</h2>
-            <p class="voucher-subtitle">{{ selected_voucher.subtitle }}</p>
-            <div class="voucher-code">Code {{ selected_voucher.code }}</div>
+            <div class="voucher-value-display" data-preview-value>{{ selected_voucher.value_display }}</div>
+            <h2 class="voucher-title" data-preview-label>{{ selected_voucher.label }}</h2>
+            <p class="voucher-subtitle" data-preview-subtitle>{{ selected_voucher.subtitle }}</p>
+            <div class="voucher-code">Code <span data-preview-code>{{ selected_voucher.code }}</span></div>
           </div>
           <div class="voucher-divider"></div>
           <div class="voucher-right">
@@ -493,19 +481,20 @@ For catering order requests, please contact: cateringorders@mcqinternational.com
               <img src="{{ url_for('static', filename='images/mcq-logo.jpg') }}" alt="MCQ logo" />
             </div>
             <h3 class="voucher-terms-title">Terms and Conditions</h3>
-            <p class="voucher-description">{{ selected_voucher.description }}</p>
-            <p class="voucher-terms">{{ selected_voucher.terms }}</p>
-            <div class="voucher-ideas">
+            <p class="voucher-description" data-preview-description>{{ selected_voucher.description }}</p>
+            <p class="voucher-terms" data-preview-terms>{{ selected_voucher.terms }}</p>
+            <div class="voucher-ideas" data-preview-items>
               {% for line in selected_voucher.included_lines %}
                 <div class="voucher-idea">{{ line }}</div>
               {% endfor %}
             </div>
-            <p class="voucher-expiry">Valid until {{ selected_voucher.expires_at }}</p>
+            <p class="voucher-expiry">Valid until <span data-preview-expiry>{{ selected_voucher.expires_at }}</span></p>
           </div>
         </div>
-        <p class="voucher-footer">{{ selected_voucher.footer_note }}</p>
+        <p class="voucher-footer" data-preview-footer>{{ selected_voucher.footer_note }}</p>
         <div class="voucher-print-actions">
           <button class="button button--primary" type="button" onclick="window.print()">Print voucher</button>
+          <button class="button button--secondary" type="button" onclick="window.print()">Save PDF</button>
         </div>
       </article>
     {% else %}
@@ -522,4 +511,69 @@ For catering order requests, please contact: cateringorders@mcqinternational.com
     {% endif %}
   </section>
 </div>
+<script>
+  (() => {
+    const valueInput = document.getElementById("voucher-value-input");
+    const valueButtons = document.querySelectorAll("[data-voucher-value]");
+    const form = document.querySelector(".voucher-create");
+    const previewValue = document.querySelector("[data-preview-value]");
+    const previewCode = document.querySelector("[data-preview-code]");
+    const previewLabel = document.querySelector("[data-preview-label]");
+    const previewSubtitle = document.querySelector("[data-preview-subtitle]");
+    const previewDescription = document.querySelector("[data-preview-description]");
+    const previewTerms = document.querySelector("[data-preview-terms]");
+    const previewItems = document.querySelector("[data-preview-items]");
+    const previewExpiry = document.querySelector("[data-preview-expiry]");
+    const previewFooter = document.querySelector("[data-preview-footer]");
+
+    function field(name) {
+      return form ? form.querySelector(`[name="${name}"]`) : null;
+    }
+
+    function money(value) {
+      const number = Number(String(value || "").replace(/[^\d.]/g, ""));
+      return number > 0 ? `$${Math.round(number)}` : "$0";
+    }
+
+    function updatePreview() {
+      if (!form) return;
+      if (previewValue) previewValue.textContent = money(field("value")?.value);
+      if (previewCode) previewCode.textContent = field("code")?.value.trim() || "AUTO";
+      if (previewLabel) previewLabel.textContent = field("label")?.value || "MCQ Voucher";
+      if (previewSubtitle) previewSubtitle.textContent = field("subtitle")?.value || "For lucky customer";
+      if (previewDescription) previewDescription.textContent = field("description")?.value || "";
+      if (previewTerms) previewTerms.textContent = field("terms")?.value || "";
+      if (previewExpiry) previewExpiry.textContent = field("expires_at")?.value || "";
+      if (previewFooter) previewFooter.textContent = field("footer_note")?.value || "";
+      if (previewItems) {
+        const lines = (field("included_items")?.value || "")
+          .split("\n")
+          .map((line) => line.trim())
+          .filter(Boolean);
+        previewItems.innerHTML = "";
+        lines.forEach((line) => {
+          const item = document.createElement("div");
+          item.className = "voucher-idea";
+          item.textContent = line;
+          previewItems.appendChild(item);
+        });
+      }
+    }
+
+    valueButtons.forEach((button) => {
+      button.addEventListener("click", () => {
+        if (valueInput) valueInput.value = button.dataset.voucherValue || "";
+        valueButtons.forEach((item) => item.classList.remove("is-selected"));
+        button.classList.add("is-selected");
+        updatePreview();
+      });
+    });
+    if (form) {
+      form.querySelectorAll("input, textarea").forEach((input) => {
+        input.addEventListener("input", updatePreview);
+      });
+      updatePreview();
+    }
+  })();
+</script>
 {% endblock %}

--- a/templates/admin/vouchers.html
+++ b/templates/admin/vouchers.html
@@ -47,16 +47,18 @@
     overflow: hidden;
     min-height: 420px;
     background:
-      linear-gradient(135deg, rgba(42, 22, 11, 0.96), rgba(155, 49, 32, 0.92)),
-      #2a160b;
+      radial-gradient(circle at 20% 12%, rgba(255, 216, 115, 0.5), transparent 28%),
+      radial-gradient(circle at 92% 22%, rgba(255, 106, 19, 0.58), transparent 25%),
+      linear-gradient(135deg, #111827 0%, #7f1d1d 45%, #f97316 100%);
     color: var(--text-inverse);
+    box-shadow: 0 26px 60px rgba(127, 29, 29, 0.34), 0 12px 28px rgba(255, 106, 19, 0.22);
   }
 
   .voucher-card::before {
     content: "";
     position: absolute;
     inset: 1rem;
-    border: 1px solid rgba(255, 216, 115, 0.32);
+    border: 2px solid rgba(255, 216, 115, 0.55);
     border-radius: 14px;
     pointer-events: none;
   }
@@ -66,6 +68,29 @@
   .voucher-ideas {
     position: relative;
     z-index: 1;
+  }
+
+  .voucher-create {
+    display: grid;
+    gap: 0.8rem;
+  }
+
+  .voucher-create textarea {
+    width: 100%;
+    min-height: 110px;
+    border-radius: 14px;
+    border: 1px solid rgba(112, 85, 66, 0.18);
+    background: rgba(255, 255, 255, 0.84);
+    box-sizing: border-box;
+    color: var(--text-main);
+    font: inherit;
+    padding: 0.8rem;
+  }
+
+  .voucher-create-actions {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 0.55rem;
   }
 
   .voucher-brand {
@@ -119,8 +144,21 @@
 
   .voucher-idea {
     border-radius: 14px;
-    background: rgba(255, 255, 255, 0.1);
+    background: rgba(255, 255, 255, 0.18);
+    border: 1px solid rgba(255, 216, 115, 0.24);
     padding: 0.75rem;
+  }
+
+  .voucher-description {
+    position: relative;
+    z-index: 1;
+    border-radius: 16px;
+    background: rgba(255, 255, 255, 0.15);
+    border: 1px solid rgba(255, 216, 115, 0.24);
+    color: rgba(255, 247, 239, 0.94);
+    line-height: 1.6;
+    margin: 1rem 0 0;
+    padding: 0.9rem;
   }
 
   .voucher-idea strong {
@@ -148,7 +186,8 @@
 
   @media (max-width: 900px) {
     .voucher-grid,
-    .voucher-ideas {
+    .voucher-ideas,
+    .voucher-create-actions {
       grid-template-columns: 1fr;
     }
   }
@@ -166,10 +205,14 @@
   <section class="voucher-grid">
     <aside class="admin-panel">
       <p class="eyebrow">Create value</p>
-      <form class="voucher-values" method="post" action="{{ url_for('admin.admin_vouchers') }}">
-        {% for value in values %}
-          <button class="voucher-value" type="submit" name="value" value="{{ value }}">${{ value }}</button>
-        {% endfor %}
+      <form class="voucher-create" method="post" action="{{ url_for('admin.admin_vouchers') }}">
+        <label class="eyebrow" for="voucher-description">Voucher includes</label>
+        <textarea id="voucher-description" name="description">Use this voucher for MCQ street-food favourites: banh mi, Vietnamese coffee, pho, rice bowls, fresh juices, and pickup combos.</textarea>
+        <div class="voucher-create-actions">
+          {% for value in values %}
+            <button class="voucher-value" type="submit" name="value" value="{{ value }}">${{ value }}</button>
+          {% endfor %}
+        </div>
       </form>
 
       <div class="voucher-list">
@@ -194,6 +237,7 @@
         <div class="voucher-value-display">{{ selected_voucher.value_display }}</div>
         <div class="voucher-code">{{ selected_voucher.code }}</div>
         <p class="voucher-meta">Created {{ selected_voucher.created_label }} · Redeem in store for pickup orders, drinks, and street-food favourites.</p>
+        <p class="voucher-description">{{ selected_voucher.description }}</p>
         <div class="voucher-ideas">
           <div class="voucher-idea">
             <strong>{{ selected_voucher.banh_mi_count }}</strong>

--- a/templates/admin/vouchers.html
+++ b/templates/admin/vouchers.html
@@ -11,7 +11,7 @@
 
   .voucher-grid {
     display: grid;
-    grid-template-columns: minmax(280px, 0.75fr) minmax(0, 1.25fr);
+    grid-template-columns: minmax(320px, 0.72fr) minmax(0, 1.28fr);
     gap: 1rem;
   }
 
@@ -45,27 +45,57 @@
   .voucher-card {
     position: relative;
     overflow: hidden;
-    min-height: 420px;
-    background:
-      radial-gradient(circle at 20% 12%, rgba(255, 216, 115, 0.5), transparent 28%),
-      radial-gradient(circle at 92% 22%, rgba(255, 106, 19, 0.58), transparent 25%),
-      linear-gradient(135deg, #111827 0%, #7f1d1d 45%, #f97316 100%);
-    color: var(--text-inverse);
-    box-shadow: 0 26px 60px rgba(127, 29, 29, 0.34), 0 12px 28px rgba(255, 106, 19, 0.22);
+    min-height: 470px;
+    background: linear-gradient(135deg, #21a74a 0%, #0c8a43 100%);
+    color: #18120d;
+    padding: 2.4rem;
+    box-shadow: 0 26px 60px rgba(7, 89, 39, 0.28), 0 12px 28px rgba(12, 138, 67, 0.22);
   }
 
   .voucher-card::before {
     content: "";
     position: absolute;
-    inset: 1rem;
-    border: 2px solid rgba(255, 216, 115, 0.55);
-    border-radius: 14px;
+    inset: auto auto 0 0;
+    width: 220px;
+    height: 260px;
+    background:
+      radial-gradient(circle at 30% 22%, #ef4444 0 9px, transparent 10px),
+      radial-gradient(circle at 58% 20%, #facc15 0 11px, transparent 12px),
+      radial-gradient(circle at 42% 36%, #22c55e 0 15px, transparent 16px),
+      linear-gradient(145deg, #0f8b54, #075f3d);
+    border-radius: 0 90px 0 0;
+    opacity: 0.95;
     pointer-events: none;
+  }
+
+  .voucher-certificate {
+    position: relative;
+    z-index: 1;
+    display: grid;
+    grid-template-columns: minmax(0, 1.05fr) 2px minmax(0, 0.95fr);
+    gap: 1.7rem;
+    min-height: 330px;
+    margin-left: clamp(0rem, 8vw, 3.8rem);
+    padding: clamp(1.1rem, 3vw, 1.7rem);
+    background: #f7f1e9;
+    box-shadow: 12px 12px 0 rgba(2, 92, 43, 0.35), 0 18px 42px rgba(42, 22, 11, 0.18);
+  }
+
+  .voucher-divider {
+    background: #d9160f;
+  }
+
+  .voucher-left,
+  .voucher-right {
+    display: grid;
+    align-content: center;
+    text-align: center;
   }
 
   .voucher-brand,
   .voucher-meta,
-  .voucher-ideas {
+  .voucher-ideas,
+  .voucher-print-actions {
     position: relative;
     z-index: 1;
   }
@@ -75,9 +105,21 @@
     gap: 0.8rem;
   }
 
+  .voucher-field {
+    display: grid;
+    gap: 0.25rem;
+  }
+
+  .voucher-field label {
+    color: var(--text-muted);
+    font-size: 0.76rem;
+    font-weight: 900;
+    text-transform: uppercase;
+  }
+
+  .voucher-field input,
   .voucher-create textarea {
     width: 100%;
-    min-height: 110px;
     border-radius: 14px;
     border: 1px solid rgba(112, 85, 66, 0.18);
     background: rgba(255, 255, 255, 0.84);
@@ -85,6 +127,10 @@
     color: var(--text-main);
     font: inherit;
     padding: 0.8rem;
+  }
+
+  .voucher-create textarea {
+    min-height: 96px;
   }
 
   .voucher-create-actions {
@@ -97,12 +143,13 @@
     display: flex;
     gap: 0.8rem;
     align-items: center;
+    justify-content: center;
   }
 
   .voucher-brand img {
-    width: 74px;
+    width: 138px;
     height: 74px;
-    border-radius: 16px;
+    border-radius: 0;
     object-fit: cover;
   }
 
@@ -115,55 +162,101 @@
   .voucher-value-display {
     position: relative;
     z-index: 1;
-    margin: 2rem 0 1rem;
+    margin: 0 0 0.55rem;
     font-family: "Bebas Neue", "Bricolage Grotesque", sans-serif;
-    font-size: clamp(4rem, 16vw, 8rem);
+    font-size: clamp(4.5rem, 13vw, 8.5rem);
     line-height: 0.85;
-    color: var(--brand-gold);
+    color: #d9160f;
+    letter-spacing: 0.02em;
   }
 
   .voucher-code {
     display: inline-flex;
     position: relative;
     z-index: 1;
-    border: 1px dashed rgba(255, 216, 115, 0.7);
+    justify-content: center;
+    border: 1px dashed rgba(217, 22, 15, 0.55);
     border-radius: 999px;
     padding: 0.55rem 0.9rem;
-    background: rgba(255, 255, 255, 0.08);
-    font-size: 1.15rem;
+    background: rgba(217, 22, 15, 0.08);
+    color: #d9160f;
+    font-size: 0.95rem;
     font-weight: 900;
     letter-spacing: 0.08em;
   }
 
   .voucher-ideas {
     display: grid;
-    grid-template-columns: repeat(3, minmax(0, 1fr));
-    gap: 0.6rem;
-    margin-top: 1.3rem;
+    gap: 0.35rem;
+    margin: 0.8rem 0 0;
+    text-align: left;
   }
 
   .voucher-idea {
-    border-radius: 14px;
-    background: rgba(255, 255, 255, 0.18);
-    border: 1px solid rgba(255, 216, 115, 0.24);
-    padding: 0.75rem;
+    border-radius: 999px;
+    background: rgba(217, 22, 15, 0.08);
+    border: 1px solid rgba(217, 22, 15, 0.12);
+    padding: 0.42rem 0.65rem;
+    font-size: 0.82rem;
   }
 
   .voucher-description {
     position: relative;
     z-index: 1;
-    border-radius: 16px;
-    background: rgba(255, 255, 255, 0.15);
-    border: 1px solid rgba(255, 216, 115, 0.24);
-    color: rgba(255, 247, 239, 0.94);
-    line-height: 1.6;
-    margin: 1rem 0 0;
-    padding: 0.9rem;
+    color: #24150c;
+    line-height: 1.55;
+    margin: 0.8rem 0;
   }
 
   .voucher-idea strong {
     display: block;
-    color: var(--brand-gold);
+    color: #d9160f;
+  }
+
+  .voucher-title {
+    margin: 0.4rem 0;
+    color: #d9160f;
+    font-weight: 900;
+    letter-spacing: 0.22em;
+    text-transform: uppercase;
+  }
+
+  .voucher-subtitle {
+    color: #d9160f;
+    font-weight: 900;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+  }
+
+  .voucher-terms-title,
+  .voucher-expiry {
+    color: #d9160f;
+    font-weight: 900;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+  }
+
+  .voucher-terms {
+    white-space: pre-line;
+    line-height: 1.45;
+    margin: 0.8rem 0 1rem;
+  }
+
+  .voucher-footer {
+    position: relative;
+    z-index: 1;
+    margin: 1.6rem 0 0 clamp(0rem, 8vw, 3.8rem);
+    color: #fff;
+    font-size: clamp(0.95rem, 2vw, 1.25rem);
+    font-style: italic;
+    line-height: 1.35;
+    white-space: pre-line;
+  }
+
+  .voucher-print-actions {
+    display: flex;
+    justify-content: flex-end;
+    margin-top: 0.9rem;
   }
 
   .voucher-list {
@@ -186,9 +279,41 @@
 
   @media (max-width: 900px) {
     .voucher-grid,
-    .voucher-ideas,
     .voucher-create-actions {
       grid-template-columns: 1fr;
+    }
+
+    .voucher-certificate {
+      grid-template-columns: 1fr;
+      margin-left: 0;
+    }
+
+    .voucher-divider {
+      height: 2px;
+    }
+  }
+
+  @media print {
+    body * {
+      visibility: hidden;
+    }
+
+    .voucher-card,
+    .voucher-card * {
+      visibility: visible;
+    }
+
+    .voucher-card {
+      position: fixed;
+      inset: 0;
+      width: 100vw;
+      min-height: 100vh;
+      border-radius: 0;
+      box-shadow: none;
+    }
+
+    .voucher-print-actions {
+      display: none;
     }
   }
 </style>
@@ -206,8 +331,40 @@
     <aside class="admin-panel">
       <p class="eyebrow">Create value</p>
       <form class="voucher-create" method="post" action="{{ url_for('admin.admin_vouchers') }}">
-        <label class="eyebrow" for="voucher-description">Voucher includes</label>
-        <textarea id="voucher-description" name="description">Use this voucher for MCQ street-food favourites: banh mi, Vietnamese coffee, pho, rice bowls, fresh juices, and pickup combos.</textarea>
+        <input type="hidden" name="action" value="create" />
+        <div class="voucher-field">
+          <label>Title</label>
+          <input name="label" value="$150 Catering Voucher" />
+        </div>
+        <div class="voucher-field">
+          <label>Subtitle</label>
+          <input name="subtitle" value="For lucky customer in 12 days of Christmas giveaway" />
+        </div>
+        <div class="voucher-field">
+          <label>Valid until</label>
+          <input name="expires_at" value="13 May 2026" />
+        </div>
+        <div class="voucher-field">
+          <label>Voucher description</label>
+          <textarea name="description">This voucher entitles the bearer to catering order value at MCQ Street Food Mirrabooka.</textarea>
+        </div>
+        <div class="voucher-field">
+          <label>Included items and quantities</label>
+          <textarea name="included_items">10 banh mi platters
+12 Vietnamese iced coffees
+8 fresh juice cups
+1 catering pickup combo</textarea>
+        </div>
+        <div class="voucher-field">
+          <label>Terms and conditions</label>
+          <textarea name="terms">This gift certificate is not redeemable for cash.
+One time use only.</textarea>
+        </div>
+        <div class="voucher-field">
+          <label>Footer contact</label>
+          <textarea name="footer_note">Authorised by MCQ Vietnamese Street Food.
+For catering order requests, please contact: cateringorders@mcqinternational.com</textarea>
+        </div>
         <div class="voucher-create-actions">
           {% for value in values %}
             <button class="voucher-value" type="submit" name="value" value="{{ value }}">${{ value }}</button>
@@ -223,34 +380,81 @@
           </a>
         {% endfor %}
       </div>
+
+      {% if selected_voucher %}
+        <form class="voucher-create" method="post" action="{{ url_for('admin.admin_vouchers') }}">
+          <input type="hidden" name="action" value="update" />
+          <input type="hidden" name="voucher_id" value="{{ selected_voucher.id }}" />
+          <p class="eyebrow">Edit selected voucher</p>
+          <div class="voucher-field">
+            <label>Unique code</label>
+            <input name="code" value="{{ selected_voucher.code }}" />
+          </div>
+          <div class="voucher-field">
+            <label>Value</label>
+            <input name="value" value="{{ selected_voucher.value }}" />
+          </div>
+          <div class="voucher-field">
+            <label>Title</label>
+            <input name="label" value="{{ selected_voucher.label }}" />
+          </div>
+          <div class="voucher-field">
+            <label>Subtitle</label>
+            <input name="subtitle" value="{{ selected_voucher.subtitle }}" />
+          </div>
+          <div class="voucher-field">
+            <label>Valid until</label>
+            <input name="expires_at" value="{{ selected_voucher.expires_at }}" />
+          </div>
+          <div class="voucher-field">
+            <label>Voucher description</label>
+            <textarea name="description">{{ selected_voucher.description }}</textarea>
+          </div>
+          <div class="voucher-field">
+            <label>Included items and quantities</label>
+            <textarea name="included_items">{{ selected_voucher.included_items }}</textarea>
+          </div>
+          <div class="voucher-field">
+            <label>Terms and conditions</label>
+            <textarea name="terms">{{ selected_voucher.terms }}</textarea>
+          </div>
+          <div class="voucher-field">
+            <label>Footer contact</label>
+            <textarea name="footer_note">{{ selected_voucher.footer_note }}</textarea>
+          </div>
+          <button class="button button--primary" type="submit">Save voucher</button>
+        </form>
+      {% endif %}
     </aside>
 
     {% if selected_voucher %}
       <article class="voucher-card">
-        <div class="voucher-brand">
-          <img src="{{ url_for('static', filename='images/mcq-logo.jpg') }}" alt="MCQ logo" />
-          <div>
-            <p class="eyebrow">MCQ Vietnamese Street Food</p>
-            <h2>Digital Gift Voucher</h2>
+        <div class="voucher-certificate">
+          <div class="voucher-left">
+            <div class="voucher-value-display">{{ selected_voucher.value_display }}</div>
+            <h2 class="voucher-title">{{ selected_voucher.label }}</h2>
+            <p class="voucher-subtitle">{{ selected_voucher.subtitle }}</p>
+            <div class="voucher-code">Code {{ selected_voucher.code }}</div>
+          </div>
+          <div class="voucher-divider"></div>
+          <div class="voucher-right">
+            <div class="voucher-brand">
+              <img src="{{ url_for('static', filename='images/mcq-logo.jpg') }}" alt="MCQ logo" />
+            </div>
+            <h3 class="voucher-terms-title">Terms and Conditions</h3>
+            <p class="voucher-description">{{ selected_voucher.description }}</p>
+            <p class="voucher-terms">{{ selected_voucher.terms }}</p>
+            <div class="voucher-ideas">
+              {% for line in selected_voucher.included_lines %}
+                <div class="voucher-idea">{{ line }}</div>
+              {% endfor %}
+            </div>
+            <p class="voucher-expiry">Valid until {{ selected_voucher.expires_at }}</p>
           </div>
         </div>
-        <div class="voucher-value-display">{{ selected_voucher.value_display }}</div>
-        <div class="voucher-code">{{ selected_voucher.code }}</div>
-        <p class="voucher-meta">Created {{ selected_voucher.created_label }} · Redeem in store for pickup orders, drinks, and street-food favourites.</p>
-        <p class="voucher-description">{{ selected_voucher.description }}</p>
-        <div class="voucher-ideas">
-          <div class="voucher-idea">
-            <strong>{{ selected_voucher.banh_mi_count }}</strong>
-            <span>banh mi serves approx.</span>
-          </div>
-          <div class="voucher-idea">
-            <strong>{{ selected_voucher.coffee_count }}</strong>
-            <span>Vietnamese coffees approx.</span>
-          </div>
-          <div class="voucher-idea">
-            <strong>{{ selected_voucher.combo_count }}</strong>
-            <span>banh mi + coffee combos approx.</span>
-          </div>
+        <p class="voucher-footer">{{ selected_voucher.footer_note }}</p>
+        <div class="voucher-print-actions">
+          <button class="button button--primary" type="button" onclick="window.print()">Print voucher</button>
         </div>
       </article>
     {% else %}

--- a/templates/admin/vouchers.html
+++ b/templates/admin/vouchers.html
@@ -1,0 +1,226 @@
+{% extends "base.html" %}
+
+{% block title %}Admin Vouchers | MCQ Vietnamese Street Food{% endblock %}
+
+{% block head %}
+<style>
+  .voucher-admin {
+    display: grid;
+    gap: 1rem;
+  }
+
+  .voucher-grid {
+    display: grid;
+    grid-template-columns: minmax(280px, 0.75fr) minmax(0, 1.25fr);
+    gap: 1rem;
+  }
+
+  .admin-panel,
+  .voucher-card {
+    border-radius: 18px;
+    border: 1px solid rgba(112, 85, 66, 0.12);
+    background: linear-gradient(180deg, rgba(255, 252, 247, 0.98), rgba(248, 236, 220, 0.94)), #fff;
+    box-shadow: 0 18px 36px rgba(53, 30, 20, 0.07);
+    padding: 1rem 1.1rem;
+  }
+
+  .voucher-values {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 0.55rem;
+    margin-top: 0.9rem;
+  }
+
+  .voucher-value {
+    min-height: 48px;
+    border: 1px solid rgba(255, 106, 19, 0.22);
+    border-radius: 14px;
+    background: rgba(255, 255, 255, 0.72);
+    color: var(--text-main);
+    cursor: pointer;
+    font: inherit;
+    font-weight: 800;
+  }
+
+  .voucher-card {
+    position: relative;
+    overflow: hidden;
+    min-height: 420px;
+    background:
+      linear-gradient(135deg, rgba(42, 22, 11, 0.96), rgba(155, 49, 32, 0.92)),
+      #2a160b;
+    color: var(--text-inverse);
+  }
+
+  .voucher-card::before {
+    content: "";
+    position: absolute;
+    inset: 1rem;
+    border: 1px solid rgba(255, 216, 115, 0.32);
+    border-radius: 14px;
+    pointer-events: none;
+  }
+
+  .voucher-brand,
+  .voucher-meta,
+  .voucher-ideas {
+    position: relative;
+    z-index: 1;
+  }
+
+  .voucher-brand {
+    display: flex;
+    gap: 0.8rem;
+    align-items: center;
+  }
+
+  .voucher-brand img {
+    width: 74px;
+    height: 74px;
+    border-radius: 16px;
+    object-fit: cover;
+  }
+
+  .voucher-brand h2 {
+    margin: 0;
+    font-family: "Bricolage Grotesque", "Be Vietnam Pro", sans-serif;
+    font-size: clamp(1.5rem, 4vw, 2.4rem);
+  }
+
+  .voucher-value-display {
+    position: relative;
+    z-index: 1;
+    margin: 2rem 0 1rem;
+    font-family: "Bebas Neue", "Bricolage Grotesque", sans-serif;
+    font-size: clamp(4rem, 16vw, 8rem);
+    line-height: 0.85;
+    color: var(--brand-gold);
+  }
+
+  .voucher-code {
+    display: inline-flex;
+    position: relative;
+    z-index: 1;
+    border: 1px dashed rgba(255, 216, 115, 0.7);
+    border-radius: 999px;
+    padding: 0.55rem 0.9rem;
+    background: rgba(255, 255, 255, 0.08);
+    font-size: 1.15rem;
+    font-weight: 900;
+    letter-spacing: 0.08em;
+  }
+
+  .voucher-ideas {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 0.6rem;
+    margin-top: 1.3rem;
+  }
+
+  .voucher-idea {
+    border-radius: 14px;
+    background: rgba(255, 255, 255, 0.1);
+    padding: 0.75rem;
+  }
+
+  .voucher-idea strong {
+    display: block;
+    color: var(--brand-gold);
+  }
+
+  .voucher-list {
+    display: grid;
+    gap: 0.5rem;
+    margin-top: 0.9rem;
+  }
+
+  .voucher-list a {
+    display: flex;
+    justify-content: space-between;
+    gap: 0.8rem;
+    border-radius: 12px;
+    background: rgba(255, 255, 255, 0.72);
+    color: var(--text-main);
+    padding: 0.65rem 0.75rem;
+    text-decoration: none;
+    font-weight: 800;
+  }
+
+  @media (max-width: 900px) {
+    .voucher-grid,
+    .voucher-ideas {
+      grid-template-columns: 1fr;
+    }
+  }
+</style>
+{% endblock %}
+
+{% block content %}
+<div class="voucher-admin">
+  <section class="admin-panel">
+    <p class="eyebrow">Digital vouchers</p>
+    <h1 class="section-title">Voucher generator</h1>
+    <p class="section-copy">Create a demo-ready MCQ voucher with a unique code, logo, and serving guide.</p>
+  </section>
+
+  <section class="voucher-grid">
+    <aside class="admin-panel">
+      <p class="eyebrow">Create value</p>
+      <form class="voucher-values" method="post" action="{{ url_for('admin.admin_vouchers') }}">
+        {% for value in values %}
+          <button class="voucher-value" type="submit" name="value" value="{{ value }}">${{ value }}</button>
+        {% endfor %}
+      </form>
+
+      <div class="voucher-list">
+        {% for voucher in vouchers %}
+          <a href="{{ url_for('admin.admin_vouchers', code=voucher.code) }}">
+            <span>{{ voucher.code }}</span>
+            <span>{{ voucher.value_display }}</span>
+          </a>
+        {% endfor %}
+      </div>
+    </aside>
+
+    {% if selected_voucher %}
+      <article class="voucher-card">
+        <div class="voucher-brand">
+          <img src="{{ url_for('static', filename='images/mcq-logo.jpg') }}" alt="MCQ logo" />
+          <div>
+            <p class="eyebrow">MCQ Vietnamese Street Food</p>
+            <h2>Digital Gift Voucher</h2>
+          </div>
+        </div>
+        <div class="voucher-value-display">{{ selected_voucher.value_display }}</div>
+        <div class="voucher-code">{{ selected_voucher.code }}</div>
+        <p class="voucher-meta">Created {{ selected_voucher.created_label }} · Redeem in store for pickup orders, drinks, and street-food favourites.</p>
+        <div class="voucher-ideas">
+          <div class="voucher-idea">
+            <strong>{{ selected_voucher.banh_mi_count }}</strong>
+            <span>banh mi serves approx.</span>
+          </div>
+          <div class="voucher-idea">
+            <strong>{{ selected_voucher.coffee_count }}</strong>
+            <span>Vietnamese coffees approx.</span>
+          </div>
+          <div class="voucher-idea">
+            <strong>{{ selected_voucher.combo_count }}</strong>
+            <span>banh mi + coffee combos approx.</span>
+          </div>
+        </div>
+      </article>
+    {% else %}
+      <article class="voucher-card">
+        <div class="voucher-brand">
+          <img src="{{ url_for('static', filename='images/mcq-logo.jpg') }}" alt="MCQ logo" />
+          <div>
+            <p class="eyebrow">MCQ Vietnamese Street Food</p>
+            <h2>Create a voucher</h2>
+          </div>
+        </div>
+        <p class="voucher-meta">Choose a value on the left to generate the first unique digital voucher.</p>
+      </article>
+    {% endif %}
+  </section>
+</div>
+{% endblock %}

--- a/templates/base.html
+++ b/templates/base.html
@@ -82,12 +82,22 @@
             <a href="{{ url_for('admin.admin_menu') }}" class="{% if request.path.startswith('/admin/menu') %}is-active{% endif %}">Menu Admin</a>
             <a href="{{ url_for('admin.admin_vouchers') }}" class="{% if request.path.startswith('/admin/vouchers') %}is-active{% endif %}">Vouchers</a>
           {% endif %}
-          <a href="{{ account_href }}" class="{% if request.path.startswith('/login') or request.path.startswith('/register') or request.path.startswith('/profile') %}is-active{% endif %}">Account</a>
+          {% if current_user and not is_admin %}
+            <a href="{{ account_href }}" class="{% if request.path.startswith('/login') or request.path.startswith('/register') or request.path.startswith('/profile') %}is-active{% endif %}">Account</a>
+          {% endif %}
         </nav>
         {% if current_user %}
-          <form method="post" action="{{ url_for('auth.logout') }}">
-            <button type="submit" class="header-cta">Logout</button>
-          </form>
+          <div class="header-actions">
+            {% if not is_admin %}
+              <form method="post" action="{{ url_for('auth.demo_admin_mode') }}">
+                <input type="hidden" name="next" value="{{ url_for('admin.admin_dashboard') }}" />
+                <button type="submit" class="header-cta">Admin Mode</button>
+              </form>
+            {% endif %}
+            <form method="post" action="{{ url_for('auth.logout') }}">
+              <button type="submit" class="header-cta">Logout</button>
+            </form>
+          </div>
         {% else %}
           <div class="header-actions">
             <form method="post" action="{{ url_for('auth.demo_admin_mode') }}">

--- a/templates/base.html
+++ b/templates/base.html
@@ -88,7 +88,13 @@
             <button type="submit" class="header-cta">Logout</button>
           </form>
         {% else %}
-          <a href="{{ url_for('auth.login') }}" class="header-cta">Login</a>
+          <div class="header-actions">
+            <form method="post" action="{{ url_for('auth.demo_admin_mode') }}">
+              <input type="hidden" name="next" value="{{ url_for('admin.admin_dashboard') }}" />
+              <button type="submit" class="header-cta">Admin Mode</button>
+            </form>
+            <a href="{{ url_for('auth.login') }}" class="header-cta">Login</a>
+          </div>
         {% endif %}
       </div>
     </header>

--- a/templates/base.html
+++ b/templates/base.html
@@ -75,7 +75,8 @@
           <a href="/membership" class="{% if request.path.startswith('/membership') or request.path.startswith('/profile') %}is-active{% endif %}">Membership</a>
           <a href="/community" class="{% if request.path.startswith('/community') or request.path.startswith('/shared-meals') or request.path.startswith('/favorites') %}is-active{% endif %}">Community</a>
           {% if is_admin %}
-            <a href="/admin/orders/queue" class="{% if request.path.startswith('/admin') %}is-active{% endif %}">Admin Queue</a>
+            <a href="/admin/orders/queue" class="{% if request.path.startswith('/admin/orders') %}is-active{% endif %}">Admin Queue</a>
+            <a href="{{ url_for('admin.admin_customers') }}" class="{% if request.path.startswith('/admin/customers') %}is-active{% endif %}">Customers</a>
           {% endif %}
           <a href="{{ account_href }}" class="{% if request.path.startswith('/login') or request.path.startswith('/register') or request.path.startswith('/profile') %}is-active{% endif %}">Account</a>
         </nav>

--- a/templates/base.html
+++ b/templates/base.html
@@ -80,6 +80,7 @@
             <a href="{{ url_for('admin.admin_orders') }}" class="{% if request.path == '/admin/orders' %}is-active{% endif %}">All Orders</a>
             <a href="{{ url_for('admin.admin_customers') }}" class="{% if request.path.startswith('/admin/customers') %}is-active{% endif %}">Customers</a>
             <a href="{{ url_for('admin.admin_menu') }}" class="{% if request.path.startswith('/admin/menu') %}is-active{% endif %}">Menu Admin</a>
+            <a href="{{ url_for('admin.admin_vouchers') }}" class="{% if request.path.startswith('/admin/vouchers') %}is-active{% endif %}">Vouchers</a>
           {% endif %}
           <a href="{{ account_href }}" class="{% if request.path.startswith('/login') or request.path.startswith('/register') or request.path.startswith('/profile') %}is-active{% endif %}">Account</a>
         </nav>

--- a/templates/base.html
+++ b/templates/base.html
@@ -75,8 +75,11 @@
           <a href="/membership" class="{% if request.path.startswith('/membership') or request.path.startswith('/profile') %}is-active{% endif %}">Membership</a>
           <a href="/community" class="{% if request.path.startswith('/community') or request.path.startswith('/shared-meals') or request.path.startswith('/favorites') %}is-active{% endif %}">Community</a>
           {% if is_admin %}
-            <a href="/admin/orders/queue" class="{% if request.path.startswith('/admin/orders') %}is-active{% endif %}">Admin Queue</a>
+            <a href="{{ url_for('admin.admin_dashboard') }}" class="{% if request.path == '/admin/' %}is-active{% endif %}">Admin</a>
+            <a href="/admin/orders/queue" class="{% if request.path.startswith('/admin/orders/queue') %}is-active{% endif %}">Admin Queue</a>
+            <a href="{{ url_for('admin.admin_orders') }}" class="{% if request.path == '/admin/orders' %}is-active{% endif %}">All Orders</a>
             <a href="{{ url_for('admin.admin_customers') }}" class="{% if request.path.startswith('/admin/customers') %}is-active{% endif %}">Customers</a>
+            <a href="{{ url_for('admin.admin_menu') }}" class="{% if request.path.startswith('/admin/menu') %}is-active{% endif %}">Menu Admin</a>
           {% endif %}
           <a href="{{ account_href }}" class="{% if request.path.startswith('/login') or request.path.startswith('/register') or request.path.startswith('/profile') %}is-active{% endif %}">Account</a>
         </nav>

--- a/templates/menu/item_detail.html
+++ b/templates/menu/item_detail.html
@@ -169,8 +169,8 @@
       {% endif %}
       <div class="item-detail__actions">
         <div class="item-detail__cart-tools">
-          <button type="button" class="button button--primary" id="detail-add-cart" data-item-id="{{ item.id }}">
-            Add to cart
+          <button type="button" class="button button--primary" id="detail-add-cart" data-item-id="{{ item.id }}" {% if item.available is sameas false %}disabled{% endif %}>
+            {{ "Unavailable" if item.available is sameas false else "Add to cart" }}
           </button>
           <div class="item-detail__qty" id="detail-qty" hidden>
             <button type="button" id="detail-decrease" aria-label="Decrease quantity">-</button>

--- a/templates/menu/menu.html
+++ b/templates/menu/menu.html
@@ -1300,7 +1300,10 @@ function buildCard(item, categoryTitle) {
 
   if (addBtn) {
     addBtn.dataset.itemId = itemId || '';
-    if (itemId && window.McqCart) {
+    if (item.available === false) {
+      addBtn.disabled = true;
+      addBtn.textContent = 'Unavailable';
+    } else if (itemId && window.McqCart) {
       addBtn.disabled = false;
       addBtn.addEventListener('click', async (e) => {
         e.stopPropagation();


### PR DESCRIPTION
This pull request adds a new admin-facing customer management feature, allowing administrators to view, search, and filter all customers (both registered and guest) in the system. It introduces a new route and a dedicated template for displaying customer information, including order statistics and account type breakdowns.

**New admin customer management interface:**

- added a new ‎`/admin/customers` route (‎`admin_customers`) that aggregates both registered users and guest customers, computes order counts and total spend, and allows filtering and searching by name, email, or account type.
- backend behaviour is kept intentionally simple and unoptimised (for now), to validate admin customer workflow, before iterating on pagination and efficient methods to aggregate data.
- created a new template `templates/admin/customers.html` that presents a searchable, filterable, and styled directory of customers, including summary statistics, account type badges, and responsive design for usability.

**TODO**
- [ ] add a intuitive way to navigate to this customer account list page..
- [ ] pagination for scalability (currently loads all customers from database into memory before filtering)
- [ ] click through to individual customer order history + settings (reset password/change email)