### PR TITLE
Add structured API error responses

### DIFF
--- a/app.py
+++ b/app.py
@@ -3,9 +3,11 @@ from pathlib import Path
 from zoneinfo import ZoneInfo
 
 from flask import Flask, has_request_context, session, url_for
+from werkzeug.exceptions import HTTPException
 
 from config import Config
 from models import Order, init_db
+from routes.api_errors import handle_api_http_exception
 from routes.auth import current_user, is_admin_user
 from routes import register_blueprints
 
@@ -68,6 +70,7 @@ def create_app(test_config: dict | None = None) -> Flask:
         }
 
     register_blueprints(app)
+    app.register_error_handler(HTTPException, handle_api_http_exception)
     return app
 
 

--- a/routes/api_errors.py
+++ b/routes/api_errors.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from typing import Any
+
+from flask import jsonify, request
+from werkzeug.exceptions import HTTPException
+
+
+_DEFAULT_ERROR_CODES = {
+    400: "bad_request",
+    401: "unauthorized",
+    403: "forbidden",
+    404: "not_found",
+    405: "method_not_allowed",
+    409: "conflict",
+    500: "internal_server_error",
+}
+
+
+def api_error_payload(
+    message: str,
+    *,
+    status: int,
+    code: str | None = None,
+    details: dict[str, Any] | list[Any] | None = None,
+    extra: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "error": message,
+        "code": code or _DEFAULT_ERROR_CODES.get(status, "error"),
+        "status": status,
+    }
+    if details is not None:
+        payload["details"] = details
+    if extra:
+        payload.update(extra)
+    return payload
+
+
+def api_error_response(
+    message: str,
+    *,
+    status: int,
+    code: str | None = None,
+    details: dict[str, Any] | list[Any] | None = None,
+    extra: dict[str, Any] | None = None,
+):
+    return jsonify(api_error_payload(message, status=status, code=code, details=details, extra=extra)), status
+
+
+def wants_api_error() -> bool:
+    return request.path.startswith("/api/")
+
+
+def handle_api_http_exception(error: HTTPException):
+    if not wants_api_error():
+        return error
+    status = error.code or 500
+    return api_error_response(
+        error.description or error.name,
+        status=status,
+        code=_DEFAULT_ERROR_CODES.get(status, error.name.lower().replace(" ", "_")),
+    )

--- a/routes/auth.py
+++ b/routes/auth.py
@@ -2,10 +2,11 @@ from __future__ import annotations
 
 from functools import wraps
 
-from flask import Blueprint, current_app, jsonify, redirect, render_template, request, session, url_for
+from flask import Blueprint, current_app, redirect, render_template, request, session, url_for
 from werkzeug.security import check_password_hash, generate_password_hash
 
 from models import User, db
+from routes.api_errors import api_error_response
 
 
 auth_bp = Blueprint("auth", __name__)
@@ -37,7 +38,12 @@ def admin_required(view_func):
         next_url = request.full_path.rstrip("?")
         login_url = url_for("auth.login", next=next_url)
         if request.path.startswith("/api/"):
-            return jsonify({"error": "admin access required", "login_url": login_url}), 403
+            return api_error_response(
+                "admin access required",
+                status=403,
+                code="admin_required",
+                extra={"login_url": login_url},
+            )
         return redirect(login_url)
 
     return wrapped

--- a/routes/cart_api.py
+++ b/routes/cart_api.py
@@ -8,6 +8,7 @@ from flask import Blueprint, current_app, jsonify, request, session
 
 from menu_catalog import find_item, format_aud, load_enriched_menu, price_to_cents
 from models import FULFILLMENT_TYPES
+from routes.api_errors import api_error_response
 
 cart_api_bp = Blueprint("cart_api", __name__, url_prefix="/api/cart")
 
@@ -114,18 +115,22 @@ def add_item():
     item_id = body.get("item_id")
     qty = _parse_quantity(body.get("quantity"), default=1)
     if not item_id or not isinstance(item_id, str):
-        return jsonify({"error": "item_id is required"}), 400
+        return api_error_response("item_id is required", status=400, code="missing_item_id")
     if qty is None:
-        return jsonify({"error": "quantity must be a whole number"}), 400
+        return api_error_response("quantity must be a whole number", status=400, code="invalid_quantity")
     if qty < 1:
-        return jsonify({"error": "quantity must be at least 1"}), 400
+        return api_error_response("quantity must be at least 1", status=400, code="invalid_quantity")
     menu = _menu()
     found = find_item(menu, item_id)
     if not found:
-        return jsonify({"error": "Unknown menu item"}), 404
+        return api_error_response("Unknown menu item", status=404, code="unknown_menu_item")
     _, item = found
     if item.get("available", True) is False:
-        return jsonify({"error": "This menu item is currently unavailable"}), 409
+        return api_error_response(
+            "This menu item is currently unavailable",
+            status=409,
+            code="menu_item_unavailable",
+        )
     lines = _get_lines()
     merged = False
     for row in lines:
@@ -144,7 +149,7 @@ def update_line(item_id: str):
     body = request.get_json(silent=True) or {}
     qty = _parse_quantity(body.get("quantity"))
     if qty is None:
-        return jsonify({"error": "quantity must be a whole number"}), 400
+        return api_error_response("quantity must be a whole number", status=400, code="invalid_quantity")
     lines = _get_lines()
     new_lines: list[dict] = []
     for row in lines:

--- a/routes/orders.py
+++ b/routes/orders.py
@@ -26,6 +26,7 @@ from models import (
     db,
 )
 from receipt_pdf import build_receipt_pdf
+from routes.api_errors import api_error_response
 from routes.auth import admin_required
 from routes.cart_api import SESSION_LINES_KEY, _build_cart_payload, _menu, _save_lines
 
@@ -1428,28 +1429,33 @@ def api_update_order_status(order_number: str):
     kitchen_notes = body.get("kitchen_notes")
 
     if next_status not in ORDER_STATUS_SEQUENCE:
-        return (
-            jsonify(
-                {
-                    "error": "status must be one of the supported order states",
-                    "allowed_statuses": list(ORDER_STATUS_SEQUENCE),
-                }
-            ),
-            400,
-    )
+        return api_error_response(
+            "status must be one of the supported order states",
+            status=400,
+            code="invalid_order_status",
+            details={"allowed_statuses": list(ORDER_STATUS_SEQUENCE)},
+            extra={"allowed_statuses": list(ORDER_STATUS_SEQUENCE)},
+        )
     if kitchen_notes is not None and not isinstance(kitchen_notes, str):
-        return jsonify({"error": "kitchen_notes must be a string when provided"}), 400
+        return api_error_response(
+            "kitchen_notes must be a string when provided",
+            status=400,
+            code="invalid_kitchen_notes",
+        )
     allowed_next_status = _next_order_status(order.order_status)
     if next_status != allowed_next_status:
-        return (
-            jsonify(
-                {
-                    "error": "status transitions must move forward one step at a time",
-                    "current_status": order.order_status,
-                    "allowed_next_status": allowed_next_status,
-                }
-            ),
-            400,
+        return api_error_response(
+            "status transitions must move forward one step at a time",
+            status=400,
+            code="invalid_status_transition",
+            details={
+                "current_status": order.order_status,
+                "allowed_next_status": allowed_next_status,
+            },
+            extra={
+                "current_status": order.order_status,
+                "allowed_next_status": allowed_next_status,
+            },
         )
 
     order.order_status = next_status

--- a/routes/user.py
+++ b/routes/user.py
@@ -11,6 +11,7 @@ from flask import Blueprint, Response, current_app, jsonify, redirect, render_te
 
 from menu_catalog import format_aud, load_enriched_menu
 from models import CommunityComment, CommunityCommentVote, CommunityPost, CommunityReaction, CommunitySave, Order, User, db
+from routes.api_errors import api_error_response
 from routes.auth import current_user
 from routes.helpers import render_feature_page
 from datetime import date as date_type
@@ -1112,7 +1113,7 @@ def support_chat():
     body = request.get_json(silent=True) or {}
     message = body.get("message", "")
     if not isinstance(message, str) or not message.strip():
-        return jsonify({"error": "message is required"}), 400
+        return api_error_response("message is required", status=400, code="missing_message")
 
     cleaned_message = " ".join(message.strip().split())
     history = _support_history()

--- a/tests/test_api_errors.py
+++ b/tests/test_api_errors.py
@@ -1,0 +1,89 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from app import create_app
+from models import db
+
+
+class TestStructuredApiErrors(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmpdir = tempfile.TemporaryDirectory()
+        db_path = Path(self.tmpdir.name) / "api-errors-test.sqlite"
+        self.app = create_app(
+            {
+                "TESTING": True,
+                "SQLALCHEMY_DATABASE_URI": f"sqlite:///{db_path}",
+                "OPENAI_API_KEY": "",
+            }
+        )
+        self.client = self.app.test_client()
+        with self.app.app_context():
+            db.drop_all()
+            db.create_all()
+
+    def tearDown(self) -> None:
+        self.tmpdir.cleanup()
+
+    def assert_api_error(self, response, *, status: int, code: str, message: str) -> dict:
+        self.assertEqual(response.status_code, status)
+        payload = response.get_json()
+        self.assertIsInstance(payload, dict)
+        self.assertEqual(payload["error"], message)
+        self.assertEqual(payload["code"], code)
+        self.assertEqual(payload["status"], status)
+        return payload
+
+    def test_cart_api_invalid_quantity_has_structured_error(self):
+        response = self.client.post(
+            "/api/cart/items",
+            json={"item_id": "pho-noodle-soup__raw-beef-pho", "quantity": "many"},
+        )
+
+        self.assert_api_error(
+            response,
+            status=400,
+            code="invalid_quantity",
+            message="quantity must be a whole number",
+        )
+
+    def test_missing_api_resource_uses_json_error_handler(self):
+        response = self.client.get("/api/orders/MCQ-NOT-FOUND")
+
+        self.assert_api_error(
+            response,
+            status=404,
+            code="not_found",
+            message="The requested URL was not found on the server. If you entered the URL manually please check your spelling and try again.",
+        )
+
+    def test_admin_api_forbidden_has_structured_error(self):
+        response = self.client.patch("/api/orders/MCQ-NOT-FOUND/status", json={"status": "Preparing"})
+
+        payload = self.assert_api_error(
+            response,
+            status=403,
+            code="admin_required",
+            message="admin access required",
+        )
+        self.assertIn("login_url", payload)
+
+    def test_support_chat_missing_message_has_structured_error(self):
+        response = self.client.post("/api/support-chat", json={"message": ""})
+
+        self.assert_api_error(
+            response,
+            status=400,
+            code="missing_message",
+            message="message is required",
+        )
+
+    def test_non_api_404_keeps_html_response(self):
+        response = self.client.get("/missing-page")
+
+        self.assertEqual(response.status_code, 404)
+        self.assertFalse(response.is_json)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add reusable structured API error helpers for JSON responses.
- Return consistent `error`, `code`, `status`, and optional `details` fields for API failures.
- Apply structured errors to cart, admin-required, order status, support chat, and `/api/*` HTTP exceptions.
- Add regression tests for structured API errors while preserving non-API HTML 404 behavior.

## Tests
- `PYTHONPATH=. venv/bin/python tests/test_api_errors.py`
- `PYTHONPATH=. venv/bin/python tests/test_menu.py`
- `PYTHONPATH=. venv/bin/python tests/test_user.py`
- `PYTHONPATH=. venv/bin/python tests/test_orders.py`

Closes #22
