### PR TITLE
Improve mobile page layouts

### DIFF
--- a/static/css/main.css
+++ b/static/css/main.css
@@ -780,6 +780,11 @@ img {
     z-index: 0;
   }
 
+  .section-panel {
+    border-radius: 22px;
+    padding: 1.05rem;
+  }
+
   .brand {
     align-items: flex-start;
   }
@@ -830,6 +835,27 @@ img {
   .main-nav a {
     width: 100%;
     text-align: left;
+    min-height: 44px;
+    justify-content: flex-start;
+    white-space: normal;
+  }
+
+  .button-row,
+  .pill-row {
+    gap: 0.55rem;
+  }
+
+  .button-row .button,
+  .header-actions .button,
+  .header-actions form .button {
+    width: 100%;
+    justify-content: center;
+  }
+
+  .button,
+  .pill {
+    white-space: normal;
+    min-width: 0;
   }
 
   .header-cta {
@@ -842,7 +868,9 @@ img {
   }
 
   .section-title {
-    font-size: clamp(2rem, 10vw, 3.3rem);
+    font-size: clamp(1.9rem, 9vw, 2.7rem);
+    line-height: 1;
+  }
   }
 
   .app-footer {

--- a/templates/admin/customers.html
+++ b/templates/admin/customers.html
@@ -354,6 +354,72 @@
       grid-template-columns: 1fr;
     }
   }
+
+  @media (max-width: 720px) {
+    .admin-customers {
+      gap: 0.85rem;
+    }
+
+    .admin-panel,
+    .admin-section,
+    .admin-stat,
+    .admin-customer {
+      border-radius: 16px;
+      padding: 0.85rem;
+    }
+
+    .admin-hero__grid,
+    .admin-hero__stats,
+    .admin-customer-list {
+      gap: 0.65rem;
+    }
+
+    .admin-section__header p,
+    .admin-stat span,
+    .admin-empty {
+      line-height: 1.4;
+    }
+
+    .admin-search-form {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 0.5rem;
+    }
+
+    .admin-search-form input[type="search"],
+    .admin-search-form select,
+    .admin-search-form .button {
+      width: 100%;
+      min-width: 0;
+    }
+
+    .admin-stat--link.is-active::after {
+      position: static;
+      display: inline-flex;
+      margin-top: 0.45rem;
+    }
+
+    .admin-customer__email,
+    .admin-customer__meta {
+      overflow-wrap: anywhere;
+    }
+
+    .admin-customer__meta {
+      gap: 0.3rem 0.65rem;
+      line-height: 1.35;
+    }
+
+    .admin-customer__actions {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      justify-content: stretch;
+      width: 100%;
+    }
+
+    .admin-row-action {
+      width: 100%;
+    }
+  }
 </style>
 {% endblock %}
 

--- a/templates/admin/orders.html
+++ b/templates/admin/orders.html
@@ -159,6 +159,65 @@
       grid-template-columns: 1fr;
     }
   }
+
+  @media (max-width: 720px) {
+    .admin-queue {
+      gap: 1rem;
+    }
+
+    .admin-panel,
+    .admin-stat,
+    .admin-section,
+    .admin-order {
+      border-radius: 18px;
+      padding: 0.9rem;
+    }
+
+    .admin-hero__grid,
+    .admin-sections,
+    .admin-orders {
+      gap: 0.75rem;
+    }
+
+    .admin-section__header p,
+    .admin-order__head p,
+    .admin-stat span,
+    .admin-empty {
+      line-height: 1.4;
+    }
+
+    .admin-order__head {
+      flex-direction: column;
+      gap: 0.55rem;
+    }
+
+    .admin-badge {
+      padding: 0.45rem 0.6rem;
+      font-size: 0.76rem;
+    }
+
+    .admin-order__meta {
+      gap: 0.5rem;
+      margin-top: 0.65rem;
+    }
+
+    .admin-order__meta-item {
+      border-radius: 14px;
+      padding: 0.68rem;
+    }
+
+    .admin-actions {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 0.5rem;
+    }
+
+    .admin-actions .button,
+    .admin-actions button {
+      width: 100%;
+      justify-content: center;
+    }
+  }
 </style>
 {% endblock %}
 

--- a/templates/menu/checkout.html
+++ b/templates/menu/checkout.html
@@ -781,12 +781,134 @@
   }
 
   @media (max-width: 820px) {
+    .checkout-shell {
+      gap: 1rem;
+    }
+
+    .checkout-hero,
+    .checkout-layout,
+    .checkout-empty {
+      padding: 1rem;
+    }
+
+    .checkout-hero__title {
+      font-size: clamp(1.95rem, 10vw, 2.7rem);
+    }
+
+    .checkout-hero .section-copy {
+      line-height: 1.5;
+      margin-bottom: 0.8rem;
+    }
+
+    .checkout-steps {
+      display: grid;
+      grid-auto-flow: column;
+      grid-auto-columns: minmax(7.3rem, max-content);
+      overflow-x: auto;
+      flex-wrap: nowrap;
+      gap: 0.55rem;
+      margin-top: 0.9rem;
+      padding-bottom: 0.3rem;
+      scroll-snap-type: x proximity;
+    }
+
+    .checkout-step {
+      padding: 0.62rem 0.72rem;
+      border-radius: 16px;
+      scroll-snap-align: start;
+      white-space: nowrap;
+    }
+
+    .checkout-step strong {
+      width: 1.55rem;
+      height: 1.55rem;
+      font-size: 0.8rem;
+    }
+
     .field-grid,
     .payment-methods,
     .fulfillment-methods,
     .checkout-hero__stats,
     .checkout-hero__visuals {
       grid-template-columns: 1fr;
+    }
+
+    .checkout-hero__visuals {
+      display: none;
+    }
+
+    .checkout-hero__card,
+    .checkout-stat,
+    .checkout-card,
+    .checkout-mini {
+      border-radius: 20px;
+      padding: 0.9rem;
+    }
+
+    .checkout-hero__card p,
+    .checkout-mini p,
+    .payment-method__card p {
+      line-height: 1.45;
+    }
+
+    .checkout-hero__stats {
+      gap: 0.55rem;
+    }
+
+    .checkout-card h2 {
+      font-size: 1.2rem;
+    }
+
+    .field-grid,
+    .checkout-form,
+    .checkout-main {
+      gap: 0.75rem;
+    }
+
+    .field input,
+    .field select,
+    .field textarea {
+      padding: 0.72rem 0.82rem;
+    }
+
+    .payment-method__card {
+      min-height: 0;
+      padding: 0.85rem;
+    }
+
+    .checkout-line {
+      grid-template-columns: 1fr;
+      gap: 0.5rem;
+      padding-block: 0.75rem;
+    }
+
+    .checkout-line__controls {
+      justify-content: space-between;
+    }
+
+    .checkout-line__price {
+      justify-self: start;
+    }
+
+    .checkout-aside {
+      display: flex;
+      flex-direction: column-reverse;
+      gap: 0.8rem;
+    }
+
+    .checkout-aside__actions {
+      position: sticky;
+      bottom: 0.65rem;
+      z-index: 5;
+      padding: 0.6rem;
+      border-radius: 18px;
+      background: rgba(255, 252, 247, 0.94);
+      border: 1px solid rgba(112, 85, 66, 0.12);
+      box-shadow: 0 14px 28px rgba(53, 30, 20, 0.12);
+    }
+
+    .checkout-submit {
+      padding-block: 0.85rem;
     }
   }
 </style>

--- a/templates/menu/menu.html
+++ b/templates/menu/menu.html
@@ -778,30 +778,56 @@
       padding: 1.2rem;
     }
 
+    .menu-hero {
+      gap: 1rem;
+    }
+
+    .menu-hero .section-copy {
+      margin-bottom: 0.8rem;
+    }
+
+    .menu-hero__title {
+      font-size: clamp(2rem, 11vw, 2.85rem);
+    }
+
+    .menu-hero__metrics {
+      gap: 0.55rem;
+    }
+
+    .menu-metric {
+      padding: 0.85rem;
+    }
+
+    .menu-metric span {
+      line-height: 1.35;
+    }
+
+    .menu-hero__scene,
     .menu-hero__visual-copy,
     .menu-hero__signal {
-      position: relative;
-      top: auto;
-      left: auto;
-      right: auto;
-      width: auto;
-      max-width: none;
-      margin: 1rem;
+      display: none;
+    }
+
+    .menu-hero__visual {
+      min-height: 0;
     }
 
     .menu-hero__preview {
-      width: auto;
+      width: 100%;
       margin-left: 0;
       grid-template-columns: 96px minmax(0, 1fr);
+      padding: 0.7rem;
+      border-radius: 18px;
     }
 
     .menu-hero__preview img {
-      min-height: 108px;
+      min-height: 96px;
     }
 
     .menu-browser__header {
       flex-direction: column;
       align-items: flex-start;
+      gap: 0.8rem;
     }
 
     .menu-browser__controls {
@@ -809,22 +835,96 @@
       justify-content: space-between;
     }
 
+    .menu-browser__search {
+      width: 100%;
+    }
+
     .menu-utility__header {
       flex-direction: column;
       align-items: flex-start;
+      gap: 0.8rem;
+    }
+
+    .menu-flow {
+      width: 100%;
+      gap: 0.7rem;
+    }
+
+    .menu-flow__switch {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      width: 100%;
+    }
+
+    .menu-flow__mode {
+      justify-content: center;
+      padding-inline: 0.65rem;
+    }
+
+    .menu-flow__summary {
+      padding: 0.75rem;
+      line-height: 1.45;
     }
 
     .menu-utility__grid {
       grid-template-columns: 1fr;
+      gap: 0.65rem;
+    }
+
+    .menu-categories {
+      display: grid;
+      grid-auto-flow: column;
+      grid-auto-columns: minmax(42vw, max-content);
+      overflow-x: auto;
+      padding-bottom: 0.35rem;
+      scroll-snap-type: x proximity;
     }
 
     .menu-category-tab {
       width: 100%;
       justify-content: space-between;
+      padding: 0.7rem;
+      scroll-snap-align: start;
     }
 
     .menu-grid {
-      grid-auto-columns: minmax(82vw, 300px);
+      grid-auto-columns: minmax(76vw, 292px);
+      gap: 0.85rem;
+    }
+
+    .menu-card {
+      border-radius: 18px;
+    }
+
+    .menu-card__media img {
+      height: 145px;
+    }
+
+    .menu-card__body {
+      padding: 0.9rem;
+      gap: 0.65rem;
+    }
+
+    .menu-card__title {
+      font-size: 1.05rem;
+      line-height: 1.2;
+    }
+
+    .menu-card__summary {
+      display: -webkit-box;
+      -webkit-line-clamp: 2;
+      -webkit-box-orient: vertical;
+      overflow: hidden;
+      line-height: 1.45;
+    }
+
+    .menu-card__sections {
+      display: none;
+    }
+
+    .menu-card__actions {
+      grid-template-columns: 1fr;
+      gap: 0.55rem;
     }
 
     .menu-cart-dock {
@@ -833,7 +933,16 @@
     }
 
     .menu-cart-dock__inner {
-      padding: 0.95rem;
+      padding: 0.8rem;
+      gap: 0.65rem;
+    }
+
+    .menu-cart-dock__details {
+      gap: 0.2rem;
+    }
+
+    .menu-cart-dock__actions {
+      gap: 0.45rem;
     }
   }
 </style>

--- a/templates/user/community.html
+++ b/templates/user/community.html
@@ -188,8 +188,109 @@
     .community-board__grid { grid-template-columns: 1fr; }
   }
   @media (max-width: 720px) {
+    .community-shell {
+      gap: 1rem;
+    }
+
+    .community-hero,
+    .community-main,
+    .community-board {
+      padding: 1rem;
+    }
+
+    .community-hero__grid,
+    .community-main__grid,
+    .community-board__grid,
+    .community-feed,
+    .community-side {
+      gap: 0.8rem;
+    }
+
+    .community-panel,
+    .community-composer,
+    .community-post,
+    .community-card,
+    .community-board-card {
+      border-radius: 18px;
+      padding: 0.85rem;
+    }
+
+    .community-panel h1 {
+      font-size: clamp(1.9rem, 10vw, 2.55rem);
+      line-height: 1.02;
+    }
+
+    .community-copy,
+    .community-card p,
+    .community-post p,
+    .community-board-card p {
+      line-height: 1.45;
+    }
+
+    .community-visual {
+      display: none;
+    }
+
+    .community-stats,
+    .community-pills {
+      gap: 0.45rem;
+    }
+
+    .community-stat,
+    .community-pill,
+    .community-tag {
+      padding: 0.45rem 0.6rem;
+      font-size: 0.78rem;
+    }
+
     .community-post,
     .community-comment-form { grid-template-columns: 1fr; }
+
+    .community-post__media {
+      min-height: 150px;
+      max-height: 185px;
+    }
+
+    .community-composer textarea {
+      min-height: 88px;
+    }
+
+    .community-form-row {
+      gap: 0.55rem;
+    }
+
+    .community-actions,
+    .community-reactions {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 0.45rem;
+    }
+
+    .community-actions form,
+    .community-reactions form,
+    .community-actions button,
+    .community-reactions button {
+      width: 100%;
+    }
+
+    .community-actions button,
+    .community-reactions button {
+      justify-content: center;
+      padding: 0.55rem 0.5rem;
+      white-space: normal;
+    }
+
+    .community-comment-form button {
+      width: 100%;
+    }
+
+    .community-side .community-card:nth-child(n + 2) p,
+    .community-board-card p {
+      display: -webkit-box;
+      -webkit-line-clamp: 2;
+      -webkit-box-orient: vertical;
+      overflow: hidden;
+    }
   }
 </style>
 {% endblock %}

--- a/templates/user/favorites.html
+++ b/templates/user/favorites.html
@@ -189,6 +189,83 @@
       grid-template-columns: 1fr;
     }
   }
+
+  @media (max-width: 720px) {
+    .saved-shell {
+      gap: 1rem;
+    }
+
+    .saved-hero,
+    .saved-board,
+    .saved-collections {
+      padding: 1rem;
+    }
+
+    .saved-hero__grid,
+    .saved-meals,
+    .saved-collection-grid {
+      gap: 0.8rem;
+    }
+
+    .saved-panel,
+    .saved-meal,
+    .saved-collection {
+      border-radius: 18px;
+      padding: 0.9rem;
+    }
+
+    .saved-panel h1 {
+      font-size: clamp(1.85rem, 10vw, 2.5rem);
+      line-height: 1.05;
+    }
+
+    .saved-panel p,
+    .saved-meal p,
+    .saved-collection p {
+      line-height: 1.45;
+    }
+
+    .saved-visual {
+      display: none;
+    }
+
+    .saved-summary {
+      gap: 0.45rem;
+      margin-top: 0.75rem;
+    }
+
+    .saved-pill,
+    .saved-meal__badge {
+      padding: 0.45rem 0.6rem;
+      font-size: 0.78rem;
+    }
+
+    .saved-meal {
+      gap: 0.65rem;
+    }
+
+    .saved-meal__media {
+      aspect-ratio: 1.5 / 1;
+      border-radius: 16px;
+    }
+
+    .saved-meal__header {
+      flex-direction: column;
+      gap: 0.45rem;
+    }
+
+    .saved-meal__actions {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 0.5rem;
+    }
+
+    .saved-meal__actions .button,
+    .saved-panel .button-row .button {
+      width: 100%;
+      justify-content: center;
+    }
+  }
 </style>
 {% endblock %}
 

--- a/templates/user/orders.html
+++ b/templates/user/orders.html
@@ -379,17 +379,113 @@
   }
 
   @media (max-width: 820px) {
+    .orders-shell {
+      gap: 1rem;
+    }
+
+    .orders-hero,
+    .orders-empty,
+    .orders-list {
+      padding: 1rem;
+    }
+
+    .orders-hero__grid,
+    .order-card__grid,
+    .order-card__timeline {
+      gap: 0.8rem;
+    }
+
+    .orders-hero .section-title {
+      font-size: clamp(1.95rem, 10vw, 2.65rem);
+    }
+
+    .orders-hero .section-copy,
+    .orders-stat span,
+    .orders-highlight p,
+    .orders-filter p,
+    .order-card__header p {
+      line-height: 1.45;
+    }
+
+    .orders-visual {
+      display: none;
+    }
+
     .orders-hero__stats,
     .orders-filter__grid {
       grid-template-columns: 1fr;
+      gap: 0.55rem;
+    }
+
+    .orders-stat,
+    .orders-filter,
+    .orders-highlight,
+    .orders-ready-banner,
+    .order-card {
+      border-radius: 20px;
+      padding: 0.9rem;
+    }
+
+    .orders-filter__grid {
+      margin-top: 0.75rem;
+    }
+
+    .orders-filter__actions,
+    .order-card__actions {
+      display: grid;
+      grid-template-columns: 1fr;
+      gap: 0.55rem;
+    }
+
+    .orders-filter__actions .button,
+    .orders-filter__actions button,
+    .order-card__actions .button,
+    .order-card__actions button,
+    .inline-form {
+      width: 100%;
     }
 
     .order-card__header {
       flex-direction: column;
+      gap: 0.65rem;
     }
 
     .order-card__badges {
       justify-content: start;
+      gap: 0.4rem;
+    }
+
+    .order-badge {
+      padding: 0.48rem 0.62rem;
+      font-size: 0.78rem;
+    }
+
+    .order-lines,
+    .order-side,
+    .order-card__timeline {
+      gap: 0.55rem;
+    }
+
+    .order-side__card,
+    .order-card__timeline-item {
+      border-radius: 16px;
+      padding: 0.78rem;
+    }
+
+    .order-card__timeline {
+      grid-template-columns: repeat(4, minmax(9rem, 1fr));
+      overflow-x: auto;
+      padding-bottom: 0.3rem;
+      scroll-snap-type: x proximity;
+    }
+
+    .order-card__timeline-item {
+      scroll-snap-align: start;
+    }
+
+    .order-card__timeline-item p,
+    .order-side__card li {
+      line-height: 1.4;
     }
   }
 </style>

--- a/templates/user/profile.html
+++ b/templates/user/profile.html
@@ -621,9 +621,126 @@
   }
 
   @media (max-width: 640px) {
+    .profile-shell {
+      gap: 1rem;
+    }
+
+    .profile-hero,
+    .profile-lower {
+      padding: 1rem;
+    }
+
+    .profile-identity {
+      gap: 0.9rem;
+    }
+
+    .profile-nameplate {
+      align-items: flex-start;
+      gap: 0.85rem;
+    }
+
+    .profile-avatar {
+      width: 58px;
+      height: 58px;
+      font-size: 1.25rem;
+    }
+
+    .profile-nameplate__text h1 {
+      font-size: clamp(1.55rem, 8vw, 2rem);
+    }
+
+    .profile-nameplate__text p {
+      line-height: 1.4;
+    }
+
+    .profile-tags {
+      gap: 0.45rem;
+    }
+
+    .profile-tag {
+      padding: 0.45rem 0.62rem;
+      font-size: 0.78rem;
+    }
+
+    .profile-tier-legend {
+      display: grid;
+      grid-auto-flow: column;
+      grid-auto-columns: minmax(8.5rem, 1fr);
+      overflow-x: auto;
+      gap: 0.5rem;
+      padding-bottom: 0.25rem;
+    }
+
+    .profile-tier-legend__label {
+      grid-column: 1 / -1;
+    }
+
+    .tier-pip {
+      min-width: 0;
+      justify-content: center;
+      text-align: center;
+    }
+
     .profile-stats-row { grid-template-columns: 1fr 1fr; }
     .profile-points__top { flex-direction: column; }
     .profile-voucher-box { min-width: 0; width: 100%; }
+
+    .profile-points,
+    .member-card-face,
+    .profile-stat,
+    .profile-benefit,
+    .profile-orders,
+    .profile-empty {
+      border-radius: 18px;
+      padding: 0.9rem;
+    }
+
+    .profile-points__number {
+      font-size: clamp(2.1rem, 14vw, 3rem);
+    }
+
+    .profile-actions {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 0.55rem;
+    }
+
+    .profile-actions .button {
+      padding-inline: 0.65rem;
+      justify-content: center;
+    }
+
+    .profile-stat__value {
+      font-size: clamp(1.15rem, 6vw, 1.55rem);
+      overflow-wrap: anywhere;
+    }
+
+    .profile-stat__label,
+    .profile-benefit p,
+    .profile-orders > p {
+      line-height: 1.4;
+    }
+
+    .profile-benefits {
+      gap: 0.55rem;
+      margin-top: 0.8rem;
+    }
+
+    .profile-benefit {
+      gap: 0.65rem;
+    }
+
+    .profile-benefit p {
+      display: -webkit-box;
+      -webkit-line-clamp: 2;
+      -webkit-box-orient: vertical;
+      overflow: hidden;
+    }
+
+    .profile-order-item {
+      gap: 0.7rem;
+      padding: 0.75rem;
+    }
   }
 </style>
 {% endblock %}


### PR DESCRIPTION
Closes #30

## Summary
- Compact mobile layouts across Menu, Checkout, Community, Profile, Orders, Favorites, and Admin pages.
- Improve the mobile nav/menu readability and make repeated actions stack cleanly on small screens.
- Reduce tall visual sections on mobile, tighten cards/forms, and keep key actions visible earlier.

## Validation
- PYTHONPATH=. venv/bin/python tests/test_menu.py
- PYTHONPATH=. venv/bin/python tests/test_orders.py
- PYTHONPATH=. venv/bin/python tests/test_user.py
- PYTHONPATH=. venv/bin/python tests/test_admin.py
