### PR TITLE
Add community feed filtering and pagination

### DIFF
--- a/routes/user.py
+++ b/routes/user.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 import requests
 from flask import Blueprint, Response, current_app, jsonify, redirect, render_template, request, session, url_for
+from sqlalchemy import func
 
 from menu_catalog import format_aud, load_enriched_menu
 from models import CommunityComment, CommunityCommentVote, CommunityPost, CommunityReaction, CommunitySave, Order, User, db
@@ -25,6 +26,18 @@ _ROOT_DIR = Path(__file__).resolve().parent.parent
 _REACTION_TYPES = ("love", "want_to_try", "saved_for_later")
 _COMMENT_FOCUS = ("taste", "portion_size", "spice_level", "drink_pairing", "pickup_timing")
 _POST_TYPES = ("meal_review", "usual_combo", "pickup_tip")
+_POST_TYPE_FILTERS = (
+    ("all", "All posts"),
+    ("meal_review", "Reviews"),
+    ("usual_combo", "Combos"),
+    ("pickup_tip", "Pickup tips"),
+)
+_COMMUNITY_SORTS = (
+    ("newest", "Newest"),
+    ("most_liked", "Most liked"),
+    ("most_saved", "Most saved"),
+)
+_COMMUNITY_PAGE_SIZE = 6
 _COMMENT_VOTE_TYPES = ("helpful", "tried_this", "good_tip")
 
 _MEMBERSHIP_TIERS = (
@@ -489,6 +502,100 @@ def _all_community_posts() -> list[CommunityPost]:
     )
 
 
+def _community_page_number() -> int:
+    try:
+        return max(1, int(request.args.get("page", "1")))
+    except (TypeError, ValueError):
+        return 1
+
+
+def _community_feed_query(post_type: str, sort_key: str):
+    query = CommunityPost.query
+    if post_type in _POST_TYPES:
+        query = query.filter(CommunityPost.post_type == post_type)
+
+    if sort_key == "most_liked":
+        reaction_counts = (
+            db.session.query(
+                CommunityReaction.post_id.label("post_id"),
+                func.count(CommunityReaction.id).label("reaction_count"),
+            )
+            .group_by(CommunityReaction.post_id)
+            .subquery()
+        )
+        return (
+            query.outerjoin(reaction_counts, CommunityPost.id == reaction_counts.c.post_id)
+            .order_by(
+                func.coalesce(reaction_counts.c.reaction_count, 0).desc(),
+                CommunityPost.created_at.desc(),
+                CommunityPost.id.desc(),
+            )
+        )
+
+    if sort_key == "most_saved":
+        save_counts = (
+            db.session.query(
+                CommunitySave.post_id.label("post_id"),
+                func.count(CommunitySave.id).label("save_count"),
+            )
+            .group_by(CommunitySave.post_id)
+            .subquery()
+        )
+        return (
+            query.outerjoin(save_counts, CommunityPost.id == save_counts.c.post_id)
+            .order_by(
+                func.coalesce(save_counts.c.save_count, 0).desc(),
+                CommunityPost.created_at.desc(),
+                CommunityPost.id.desc(),
+            )
+        )
+
+    return query.order_by(CommunityPost.created_at.desc(), CommunityPost.id.desc())
+
+
+def _community_feed_context(menu_lookup: dict[str, dict], identity_key: str) -> dict:
+    post_type = request.args.get("type", "all")
+    if post_type != "all" and post_type not in _POST_TYPES:
+        post_type = "all"
+
+    sort_key = request.args.get("sort", "newest")
+    if sort_key not in {key for key, _label in _COMMUNITY_SORTS}:
+        sort_key = "newest"
+
+    query = _community_feed_query(post_type, sort_key)
+    total_posts = query.count()
+    total_pages = max(1, (total_posts + _COMMUNITY_PAGE_SIZE - 1) // _COMMUNITY_PAGE_SIZE)
+    page = min(_community_page_number(), total_pages)
+    raw_posts = (
+        query.offset((page - 1) * _COMMUNITY_PAGE_SIZE)
+        .limit(_COMMUNITY_PAGE_SIZE)
+        .all()
+    )
+    visible_from = ((page - 1) * _COMMUNITY_PAGE_SIZE + 1) if total_posts else 0
+    visible_to = min(page * _COMMUNITY_PAGE_SIZE, total_posts)
+    return {
+        "posts": [_serialize_community_post(post, menu_lookup, identity_key) for post in raw_posts],
+        "community_filters": {
+            "type": post_type,
+            "sort": sort_key,
+        },
+        "community_filter_options": _POST_TYPE_FILTERS,
+        "community_sort_options": _COMMUNITY_SORTS,
+        "community_pagination": {
+            "page": page,
+            "page_size": _COMMUNITY_PAGE_SIZE,
+            "total_posts": total_posts,
+            "total_pages": total_pages,
+            "has_previous": page > 1,
+            "has_next": page < total_pages,
+            "previous_page": max(1, page - 1),
+            "next_page": min(total_pages, page + 1),
+            "visible_from": visible_from,
+            "visible_to": visible_to,
+        },
+    }
+
+
 def _saved_meals_context() -> dict:
     identity_key, _name, _email = _community_identity()
     menu_lookup = _menu_item_lookup()
@@ -549,21 +656,22 @@ def _community_context() -> dict:
     identity_key, member_name, _email = _community_identity()
     menu_lookup = _menu_item_lookup()
     raw_posts = _all_community_posts()
-    posts = [_serialize_community_post(post, menu_lookup, identity_key) for post in raw_posts]
+    feed_context = _community_feed_context(menu_lookup, identity_key)
+    board_posts = [_serialize_community_post(post, menu_lookup, identity_key) for post in raw_posts]
     orders = _active_customer_orders()
     shared_order = _share_order_context(request.args.get("order"), menu_lookup)
     remix_post = _remix_context(request.args.get("remix"))
     today = raw_posts[0].created_at.date() if raw_posts else None
-    today_posts = [post for post in posts if today and post["created_label"] == today.strftime("%d %b %Y")][:4]
-    most_liked = sorted(posts, key=lambda post: (post["like_count"], post["comment_count"]), reverse=True)[:4]
+    today_posts = [post for post in board_posts if today and post["created_label"] == today.strftime("%d %b %Y")][:4]
+    most_liked = sorted(board_posts, key=lambda post: (post["like_count"], post["comment_count"]), reverse=True)[:4]
     quick_lunch = [
-        post for post in posts
+        post for post in board_posts
         if any(keyword in f"{post['meal']} {post['caption']}".lower() for keyword in ("banh mi", "rice", "roll", "quick", "lunch"))
     ][:4]
-    pickup_combos = [post for post in posts if post["order_number"] or "combo" in post["caption"].lower()][:4]
+    pickup_combos = [post for post in board_posts if post["order_number"] or "combo" in post["caption"].lower()][:4]
     return {
         "member_name": member_name,
-        "posts": posts,
+        **feed_context,
         "shared_order": shared_order,
         "remix_post": remix_post,
         "recent_orders": [

--- a/templates/user/community.html
+++ b/templates/user/community.html
@@ -134,6 +134,74 @@
     gap: 0.5rem;
     margin-top: 0.8rem;
   }
+  .community-feed-controls {
+    display: grid;
+    gap: 0.85rem;
+    padding: 1rem;
+    border: 1px solid rgba(112, 85, 66, 0.14);
+    border-radius: 22px;
+    background: rgba(255, 252, 247, 0.96);
+    box-shadow: 0 18px 38px rgba(53, 30, 20, 0.07);
+  }
+  .community-feed-controls__header,
+  .community-filter-row,
+  .community-pagination {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.65rem;
+    align-items: center;
+    justify-content: space-between;
+  }
+  .community-feed-controls__header h2 {
+    margin: 0;
+    font-family: "Bricolage Grotesque", "Be Vietnam Pro", sans-serif;
+    font-size: 1.25rem;
+  }
+  .community-feed-count {
+    color: var(--text-muted);
+    font-size: 0.9rem;
+  }
+  .community-filter-tabs {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.45rem;
+  }
+  .community-filter-tab {
+    display: inline-flex;
+    align-items: center;
+    min-height: 40px;
+    padding: 0.48rem 0.72rem;
+    border-radius: 999px;
+    border: 1px solid rgba(112, 85, 66, 0.16);
+    background: rgba(255, 255, 255, 0.74);
+    color: var(--text-main);
+    text-decoration: none;
+    font-weight: 800;
+    font-size: 0.84rem;
+  }
+  .community-filter-tab.is-active {
+    color: var(--brand-red);
+    border-color: rgba(255, 106, 19, 0.36);
+    background: rgba(255, 106, 19, 0.1);
+  }
+  .community-sort-form {
+    display: inline-flex;
+    gap: 0.45rem;
+    align-items: center;
+  }
+  .community-sort-form select {
+    min-height: 40px;
+    border: 1px solid rgba(112, 85, 66, 0.18);
+    border-radius: 999px;
+    padding: 0 2.2rem 0 0.85rem;
+    font: inherit;
+    font-weight: 700;
+    background: rgba(255, 255, 255, 0.88);
+  }
+  .community-pagination {
+    justify-content: center;
+    margin-top: 0.2rem;
+  }
   .community-comments { display: grid; gap: 0.45rem; margin-top: 0.8rem; }
   .community-comment {
     border-left: 3px solid rgba(0, 111, 116, 0.28);
@@ -190,6 +258,32 @@
   @media (max-width: 720px) {
     .community-post,
     .community-comment-form { grid-template-columns: 1fr; }
+
+    .community-feed-controls {
+      border-radius: 18px;
+      padding: 0.85rem;
+    }
+
+    .community-feed-controls__header,
+    .community-filter-row,
+    .community-sort-form {
+      align-items: stretch;
+      flex-direction: column;
+    }
+
+    .community-filter-tabs {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      gap: 0.45rem;
+    }
+
+    .community-filter-tab,
+    .community-sort-form select,
+    .community-sort-form button,
+    .community-pagination .button {
+      width: 100%;
+      justify-content: center;
+    }
   }
 </style>
 {% endblock %}
@@ -272,6 +366,42 @@
           </form>
         </article>
 
+        <section class="community-feed-controls" aria-label="Community feed controls">
+          <div class="community-feed-controls__header">
+            <div>
+              <p class="eyebrow">Community feed</p>
+              <h2>Browse posts</h2>
+            </div>
+            <span class="community-feed-count">
+              {% if community_pagination.total_posts %}
+                Showing {{ community_pagination.visible_from }}-{{ community_pagination.visible_to }} of {{ community_pagination.total_posts }}
+              {% else %}
+                No matching posts
+              {% endif %}
+            </span>
+          </div>
+          <div class="community-filter-row">
+            <nav class="community-filter-tabs" aria-label="Post type filters">
+              {% for filter_value, filter_label in community_filter_options %}
+                <a
+                  class="community-filter-tab {% if community_filters.type == filter_value %}is-active{% endif %}"
+                  href="{{ url_for('user.shared_meals', type=filter_value, sort=community_filters.sort) }}"
+                >{{ filter_label }}</a>
+              {% endfor %}
+            </nav>
+            <form class="community-sort-form" method="get" action="{{ url_for('user.shared_meals') }}">
+              <input type="hidden" name="type" value="{{ community_filters.type }}">
+              <label for="community-sort">Sort</label>
+              <select id="community-sort" name="sort">
+                {% for sort_value, sort_label in community_sort_options %}
+                  <option value="{{ sort_value }}" {% if community_filters.sort == sort_value %}selected{% endif %}>{{ sort_label }}</option>
+                {% endfor %}
+              </select>
+              <button class="button button--secondary" type="submit">Apply</button>
+            </form>
+          </div>
+        </section>
+
         {% if posts %}
           {% for post in posts %}
             <article class="community-post" id="post-{{ post.id }}">
@@ -344,8 +474,19 @@
           {% endfor %}
         {% else %}
           <div class="community-empty">
-            No community posts yet. Share a meal from a recent order or write the first customer tip.
+            No community posts match this filter yet. Try another post type or share the first matching story.
           </div>
+        {% endif %}
+        {% if community_pagination.total_pages > 1 %}
+          <nav class="community-pagination" aria-label="Community feed pages">
+            {% if community_pagination.has_previous %}
+              <a class="button button--secondary" href="{{ url_for('user.shared_meals', type=community_filters.type, sort=community_filters.sort, page=community_pagination.previous_page) }}">Previous</a>
+            {% endif %}
+            <span class="community-feed-count">Page {{ community_pagination.page }} of {{ community_pagination.total_pages }}</span>
+            {% if community_pagination.has_next %}
+              <a class="button button--primary" href="{{ url_for('user.shared_meals', type=community_filters.type, sort=community_filters.sort, page=community_pagination.next_page) }}">Load more</a>
+            {% endif %}
+          </nav>
         {% endif %}
       </div>
 

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -1,12 +1,12 @@
 import tempfile
 import unittest
-from datetime import datetime
+from datetime import datetime, timedelta
 from pathlib import Path
 from unittest.mock import Mock, patch
 from zoneinfo import ZoneInfo
 
 from app import create_app
-from models import Order, OrderLineItem, db
+from models import CommunityPost, CommunityReaction, CommunitySave, Order, OrderLineItem, db
 
 
 class TestSupportChat(unittest.TestCase):
@@ -139,6 +139,68 @@ class TestSupportChat(unittest.TestCase):
         self.assertIn("MCQ Community", community_html)
         self.assertIn("Share Meal Story", community_html)
         self.assertIn("Story composer", community_html)
+
+    def test_community_feed_filters_sorts_and_paginates(self):
+        with self.app.app_context():
+            base_time = datetime(2026, 5, 1, 12, 0, 0)
+            posts = []
+            for index in range(8):
+                post_type = ("meal_review", "usual_combo", "pickup_tip")[index % 3]
+                post = CommunityPost(
+                    author_name=f"Customer {index}",
+                    identity_key=f"guest:{index}",
+                    post_type=post_type,
+                    meal_name=f"{post_type} meal {index}",
+                    caption=f"Caption {index}",
+                    created_at=base_time + timedelta(minutes=index),
+                )
+                db.session.add(post)
+                posts.append(post)
+            db.session.flush()
+            db.session.add_all(
+                CommunityReaction(
+                    post_id=posts[0].id,
+                    identity_key=f"fan:{index}",
+                    author_name=f"Fan {index}",
+                    reaction_type="love",
+                )
+                for index in range(4)
+            )
+            db.session.add_all(
+                CommunitySave(
+                    post_id=posts[1].id,
+                    identity_key=f"saver:{index}",
+                    author_name=f"Saver {index}",
+                )
+                for index in range(3)
+            )
+            db.session.commit()
+
+        response = self.client.get("/community")
+        self.assertEqual(response.status_code, 200)
+        html = response.get_data(as_text=True)
+        self.assertIn("Showing 1-6 of 8", html)
+        self.assertIn("Load more", html)
+        self.assertIn("Page 1 of 2", html)
+
+        filtered = self.client.get("/community?type=pickup_tip")
+        filtered_html = filtered.get_data(as_text=True)
+        self.assertIn("<h3>pickup_tip meal 2</h3>", filtered_html)
+        self.assertNotIn("<h3>meal_review meal 0</h3>", filtered_html)
+
+        liked = self.client.get("/community?sort=most_liked")
+        liked_html = liked.get_data(as_text=True)
+        self.assertLess(
+            liked_html.index("meal_review meal 0"),
+            liked_html.index("usual_combo meal 7"),
+        )
+
+        saved = self.client.get("/community?sort=most_saved")
+        saved_html = saved.get_data(as_text=True)
+        self.assertLess(
+            saved_html.index("usual_combo meal 1"),
+            saved_html.index("usual_combo meal 7"),
+        )
 
     @patch("routes.user.requests.post")
     def test_support_chat_uses_openai_when_configured(self, mock_post):


### PR DESCRIPTION
Closes #28 #27

## Summary
- Add Community feed filters for reviews, combos, and pickup tips.
- Add sorting by newest, most liked, and most saved.
- Add paginated feed controls with previous/load more navigation.

## Validation
- PYTHONPATH=. venv/bin/python tests/test_user.py
- PYTHONPATH=. venv/bin/python tests/test_point_and_stats.py
