### PR TITLE
Improve favorites community save management

### DIFF
--- a/routes/user.py
+++ b/routes/user.py
@@ -528,19 +528,36 @@ def _saved_meals_context() -> dict:
         {"title": "Shareable meal board", "text": "Saved community posts and pickup ideas collected from other customers.", "accent": "teal"},
         {"title": "Weekend comfort stack", "text": "A saved lane for rich bowls, hot plates, and dessert add-ons.", "accent": "plum"},
     ]
-    saved_posts = (
-        CommunityPost.query.join(CommunitySave)
+    saved_records = (
+        CommunitySave.query.join(CommunityPost)
         .filter(CommunitySave.identity_key == identity_key)
-        .order_by(CommunitySave.created_at.desc())
-        .limit(6)
+        .order_by(CommunitySave.created_at.desc(), CommunitySave.id.desc())
+        .limit(12)
         .all()
     )
+    saved_posts = []
+    for save in saved_records:
+        serialized = _serialize_community_post(save.post, menu_lookup, identity_key)
+        saved_posts.append(
+            {
+                **serialized,
+                "save_id": save.id,
+                "saved_label": save.created_at.strftime("%d %b %Y"),
+                "save_status": "Saved to meal board",
+                "save_type_label": save.save_type.replace("_", " ").title(),
+            }
+        )
+    saved_type_counts = Counter(post["type_label"] for post in saved_posts)
     return {
         "saved_items": saved_items[:6],
-        "saved_community_posts": [
-            _serialize_community_post(post, menu_lookup, identity_key)
-            for post in saved_posts
-        ],
+        "saved_community_posts": saved_posts,
+        "saved_community_summary": {
+            "total": len(saved_posts),
+            "reviews": saved_type_counts["Meal Review"],
+            "combos": saved_type_counts["Usual Combo"],
+            "pickup_tips": saved_type_counts["Pickup Tip"],
+            "latest": saved_posts[0]["saved_label"] if saved_posts else "Nothing saved yet",
+        },
         "collections": collections,
     }
 
@@ -1062,6 +1079,7 @@ def save_community_post(post_id: int):
     existing = CommunitySave.query.filter_by(post_id=post.id, identity_key=identity_key).first()
     if existing:
         db.session.delete(existing)
+        session["favorites_notice"] = f"Removed {post.meal_name} from Favorites."
     else:
         db.session.add(
             CommunitySave(
@@ -1071,8 +1089,25 @@ def save_community_post(post_id: int):
                 save_type="favorite_board",
             )
         )
+        session["favorites_notice"] = f"Saved {post.meal_name} to Favorites."
     db.session.commit()
+    session.modified = True
     return redirect(url_for("user.shared_meals", _anchor=f"post-{post.id}"))
+
+
+@user_bp.post("/favorites/community/<int:post_id>/remove")
+def remove_favorite_community_post(post_id: int):
+    post = CommunityPost.query.get_or_404(post_id)
+    identity_key, _author_name, _email = _community_identity()
+    existing = CommunitySave.query.filter_by(post_id=post.id, identity_key=identity_key).first()
+    if existing:
+        db.session.delete(existing)
+        db.session.commit()
+        session["favorites_notice"] = f"Removed {post.meal_name} from your saved community posts."
+    else:
+        session["favorites_notice"] = "That community post was already removed from your Favorites."
+    session.modified = True
+    return redirect(url_for("user.favorites", _anchor="community-saves"))
 
 
 @user_bp.post("/community/comments/<int:comment_id>/vote")

--- a/templates/user/favorites.html
+++ b/templates/user/favorites.html
@@ -160,6 +160,43 @@
     margin-top: auto;
   }
 
+  .saved-status {
+    display: grid;
+    gap: 0.4rem;
+    padding: 0.85rem;
+    border-radius: 18px;
+    color: var(--brand-teal);
+    background: rgba(0, 111, 116, 0.08);
+    border: 1px solid rgba(0, 111, 116, 0.14);
+  }
+
+  .saved-status strong {
+    font-family: "Bricolage Grotesque", "Be Vietnam Pro", sans-serif;
+  }
+
+  .saved-status span {
+    color: var(--text-muted);
+    line-height: 1.45;
+  }
+
+  .saved-notice {
+    margin-top: 1rem;
+    border-color: rgba(255, 106, 19, 0.2);
+    color: var(--brand-red);
+    background: rgba(255, 106, 19, 0.08);
+  }
+
+  .saved-remove-form {
+    display: inline-flex;
+  }
+
+  .saved-remove-button {
+    border: 1px solid rgba(179, 48, 64, 0.22);
+    color: #b33040;
+    background: rgba(179, 48, 64, 0.06);
+    cursor: pointer;
+  }
+
   .saved-collection-grid {
     grid-template-columns: repeat(3, minmax(0, 1fr));
   }
@@ -193,6 +230,7 @@
 {% endblock %}
 
 {% block content %}
+{% set favorites_notice = session.pop('favorites_notice', None) %}
 <div class="saved-shell">
   <section class="saved-hero section-panel">
     <div class="saved-hero__grid">
@@ -206,8 +244,15 @@
           <span class="saved-pill">{{ membership.current_tier.name }}</span>
           <span class="saved-pill saved-pill--muted">{{ membership.points_display }} points</span>
           <span class="saved-pill saved-pill--muted">{{ saved_items|length }} saved meal cards on screen</span>
-          <span class="saved-pill saved-pill--muted">{{ saved_community_posts|length }} community saves</span>
+          <span class="saved-pill saved-pill--muted">{{ saved_community_summary.total }} community saves</span>
+          <span class="saved-pill saved-pill--muted">Latest: {{ saved_community_summary.latest }}</span>
         </div>
+        {% if favorites_notice %}
+          <div class="saved-status saved-notice">
+            <strong>Favorites updated</strong>
+            <span>{{ favorites_notice }}</span>
+          </div>
+        {% endif %}
         <div class="button-row" style="margin-top: 1rem;">
           <a href="/community" class="button button--primary">Share in MCQ Community</a>
           <a href="/menu" class="button button--secondary">Browse Menu</a>
@@ -224,9 +269,15 @@
     </div>
   </section>
 
-  <section class="saved-board section-panel">
+  <section class="saved-board section-panel" id="community-saves">
     <p class="eyebrow">Community saves</p>
     <h2>Meal ideas saved from customer posts</h2>
+    <div class="saved-summary">
+      <span class="saved-pill">{{ saved_community_summary.total }} saved posts</span>
+      <span class="saved-pill saved-pill--muted">{{ saved_community_summary.reviews }} reviews</span>
+      <span class="saved-pill saved-pill--muted">{{ saved_community_summary.combos }} combos</span>
+      <span class="saved-pill saved-pill--muted">{{ saved_community_summary.pickup_tips }} pickup tips</span>
+    </div>
     {% if saved_community_posts %}
       <div class="saved-meals">
         {% for post in saved_community_posts %}
@@ -236,15 +287,25 @@
             </div>
             <div class="saved-meal__header">
               <div>
-                <p class="saved-meal__meta">{{ post.author }} · {{ post.type_label }}</p>
+                <p class="saved-meal__meta">{{ post.author }} · {{ post.type_label }} · saved {{ post.saved_label }}</p>
                 <h3 class="saved-meal__title">{{ post.meal }}</h3>
               </div>
               <span class="saved-meal__badge">{{ post.save_count }} saves</span>
             </div>
+            <div class="saved-status">
+              <strong>{{ post.save_status }}</strong>
+              <span>{{ post.like_count }} reactions · {{ post.comment_count }} comments · {{ post.save_type_label }}</span>
+            </div>
             <p>{{ post.caption }}</p>
+            {% if post.tip %}
+              <p><strong>Saved tip:</strong> {{ post.tip }}</p>
+            {% endif %}
             <div class="saved-meal__actions">
               <a href="{{ url_for('user.shared_meals') }}#post-{{ post.id }}" class="button button--secondary">Open Post</a>
               <a href="/menu" class="button button--secondary">Build Similar Order</a>
+              <form class="saved-remove-form" method="post" action="{{ url_for('user.remove_favorite_community_post', post_id=post.id) }}">
+                <button class="button saved-remove-button" type="submit">Remove Saved Post</button>
+              </form>
             </div>
           </article>
         {% endfor %}

--- a/tests/test_user.py
+++ b/tests/test_user.py
@@ -6,7 +6,7 @@ from unittest.mock import Mock, patch
 from zoneinfo import ZoneInfo
 
 from app import create_app
-from models import Order, OrderLineItem, db
+from models import CommunityPost, CommunitySave, Order, OrderLineItem, db
 
 
 class TestSupportChat(unittest.TestCase):
@@ -139,6 +139,51 @@ class TestSupportChat(unittest.TestCase):
         self.assertIn("MCQ Community", community_html)
         self.assertIn("Share Meal Story", community_html)
         self.assertIn("Story composer", community_html)
+
+    def test_favorites_can_manage_saved_community_posts(self):
+        self._login_customer()
+        with self.app.app_context():
+            post = CommunityPost(
+                author_name="Community Fan",
+                identity_key="guest:fan",
+                post_type="pickup_tip",
+                meal_name="Crispy pork banh mi",
+                caption="Ask for extra herbs and keep the sauce separate for pickup.",
+                tip="Best within 10 minutes of pickup.",
+            )
+            db.session.add(post)
+            db.session.flush()
+            db.session.add(
+                CommunitySave(
+                    post_id=post.id,
+                    identity_key="user:member@example.com",
+                    author_name="Lantern Member",
+                    save_type="favorite_board",
+                )
+            )
+            db.session.commit()
+            post_id = post.id
+
+        favorites = self.client.get("/favorites")
+        self.assertEqual(favorites.status_code, 200)
+        html = favorites.get_data(as_text=True)
+        self.assertIn("Crispy pork banh mi", html)
+        self.assertIn("Remove Saved Post", html)
+        self.assertIn("1 pickup tips", html)
+        self.assertIn("Saved to meal board", html)
+
+        response = self.client.post(
+            f"/favorites/community/{post_id}/remove",
+            follow_redirects=True,
+        )
+        self.assertEqual(response.status_code, 200)
+        removed_html = response.get_data(as_text=True)
+        self.assertIn("Favorites updated", removed_html)
+        self.assertIn("Removed Crispy pork banh mi", removed_html)
+        self.assertNotIn("Remove Saved Post", removed_html)
+
+        with self.app.app_context():
+            self.assertEqual(CommunitySave.query.count(), 0)
 
     @patch("routes.user.requests.post")
     def test_support_chat_uses_openai_when_configured(self, mock_post):


### PR DESCRIPTION
Closes #29

## Summary
- Add a remove-from-favorites action for saved community posts.
- Improve Favorites display with saved date, save status, reaction/comment counts, and post type summary.
- Add user-facing feedback after save/remove actions.

## Validation
- PYTHONPATH=. venv/bin/python tests/test_user.py
- PYTHONPATH=. venv/bin/python tests/test_point_and_stats.py
