### PR TITLE
homepage ui updates

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -504,29 +504,29 @@
     padding: 1rem 1rem 1.1rem;
   }
 
-  .gallery-card__tag {
-    display: inline-flex;
-    align-items: center;
-    padding: 0.34rem 0.66rem;
-    border-radius: 999px;
-    font-size: 0.76rem;
-    font-weight: 800;
-    letter-spacing: 0.08em;
-    text-transform: uppercase;
-    color: var(--brand-teal);
-    background: rgba(0, 111, 116, 0.08);
+  .gallery-card__title-row {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 0.7rem;
   }
 
   .gallery-card h3 {
-    margin: 0.75rem 0 0.45rem;
+    margin: 0 0 0.45rem;
     font-family: "Bricolage Grotesque", "Be Vietnam Pro", sans-serif;
     font-size: 1.2rem;
+  }
+
+  .gallery-card__price {
+    font-weight: 800;
+    color: var(--brand-red);
+    white-space: nowrap;
   }
 
   .gallery-card p {
     margin: 0;
     color: var(--text-muted);
-    line-height: 1.65;
+    line-height: 1.45;
   }
 
   .support-story {
@@ -693,20 +693,15 @@
 <section class="street-gallery section-panel">
   <div class="street-gallery__header">
     <div class="street-gallery__header-copy">
-      <p class="eyebrow">Street food inspiration</p>
-      <h2>Ben Thanh character plus your street-food photo set</h2>
-      <p>
-        The refreshed visual direction now mixes your supplied Ben Thanh artwork with your new street-food images and a
-        small amount of appetite imagery already in the project to keep the interface varied and more lived-in.
-      </p>
+      <h2>Best Sellers</h2>
     </div>
-    <div class="street-gallery__controls" aria-label="Street food inspiration controls">
+    <div class="street-gallery__controls" aria-label="Best seller controls">
       <span class="street-gallery__hint">Swipe or slide</span>
       <button
         class="street-gallery__control"
         type="button"
         data-gallery-shift="-1"
-        aria-label="Scroll street food inspiration left"
+        aria-label="Scroll best sellers left"
       >
         &larr;
       </button>
@@ -714,7 +709,7 @@
         class="street-gallery__control"
         type="button"
         data-gallery-shift="1"
-        aria-label="Scroll street food inspiration right"
+        aria-label="Scroll best sellers right"
       >
         &rarr;
       </button>
@@ -723,121 +718,104 @@
   <div class="street-gallery__rail" id="street-gallery-rail">
   <div class="street-gallery__grid">
     <article class="gallery-card">
-      <img src="{{ url_for('static', filename='images/brand/benthanh.jpg') }}" alt="Ben Thanh Market inspired artwork" />
+      <img src="{{ url_for('static', filename='images/menu/items/mcq-special-pho.jpg') }}" alt="MCQ Special Pho in broth with herbs" />
       <div class="gallery-card__body">
-        <span class="gallery-card__tag">Local asset</span>
-        <h3>Ben Thanh Signature</h3>
-        <p>Your attached Ben Thanh illustration now anchors the Saigon identity instead of being a loose reference.</p>
+        <div class="gallery-card__title-row">
+          <h3>MCQ Special Pho</h3>
+          <span class="gallery-card__price">$17</span>
+        </div>
+        <p>Signature mixed-beef pho with rich broth.</p>
       </div>
     </article>
     <article class="gallery-card">
       <img
-        src="{{ url_for('static', filename='images/inspiration/street-food-life.jpg') }}"
-        alt="Street food scene inspiration"
+        src="{{ url_for('static', filename='images/menu/items/slow-cooked-beef-rib-pho.jpg') }}"
+        alt="Slow-cooked beef rib pho with fresh garnish"
       />
       <div class="gallery-card__body">
-        <span class="gallery-card__tag">Online source</span>
-        <h3>Street-side Energy</h3>
-        <p>Used to bring in the feel of everyday Vietnamese food culture and a busier, more lived-in atmosphere.</p>
+        <div class="gallery-card__title-row">
+          <h3>Slow-Cooked Beef Rib Pho</h3>
+          <span class="gallery-card__price">$17</span>
+        </div>
+        <p>Deep, slow-simmered broth with tender rib.</p>
       </div>
     </article>
     <article class="gallery-card">
       <img
-        src="{{ url_for('static', filename='images/inspiration/streetfood-1.jpg') }}"
-        alt="Vietnamese tray meal with herbs and noodles"
+        src="{{ url_for('static', filename='images/menu/items/grilled-pork-chop-with-broken-rice.jpg') }}"
+        alt="Grilled pork chop with broken rice and sides"
       />
       <div class="gallery-card__body">
-        <span class="gallery-card__tag">Your image</span>
-        <h3>Tray-and-Herb Street Detail</h3>
-        <p>This image adds a more casual curb-side meal moment and helps the feature pages feel less repetitive.</p>
+        <div class="gallery-card__title-row">
+          <h3>Grilled Pork Chop with Broken Rice</h3>
+          <span class="gallery-card__price">$17</span>
+        </div>
+        <p>Classic lunch plate with full savory sides.</p>
       </div>
     </article>
     <article class="gallery-card">
       <img
-        src="{{ url_for('static', filename='images/inspiration/streetfood-4.jpg') }}"
-        alt="Vietnamese floating market boats"
+        src="{{ url_for('static', filename='images/menu/items/mcq-sizzling-beef-with-bread.jpg') }}"
+        alt="Sizzling beef with bread and sunny side egg"
       />
       <div class="gallery-card__body">
-        <span class="gallery-card__tag">Your image</span>
-        <h3>Floating Market Colour</h3>
-        <p>Boat markets add a broader Vietnam mood and make the brand world feel bigger than one single food counter.</p>
+        <div class="gallery-card__title-row">
+          <h3>MCQ Sizzling Beef with Bread</h3>
+          <span class="gallery-card__price">$17</span>
+        </div>
+        <p>Hotplate favorite with steak, egg, and bread.</p>
       </div>
     </article>
     <article class="gallery-card">
       <img
-        src="{{ url_for('static', filename='images/inspiration/streetfood-5.jpg') }}"
-        alt="Vietnamese produce market stall"
+        src="{{ url_for('static', filename='images/menu/items/roast-pork-banh-mi.jpg') }}"
+        alt="Roast pork banh mi on crusty bread"
       />
       <div class="gallery-card__body">
-        <span class="gallery-card__tag">Your image</span>
-        <h3>Wet Market Produce</h3>
-        <p>Vegetable baskets and market colour help the site feel rooted in daily Vietnamese food culture, not just plated dishes.</p>
+        <div class="gallery-card__title-row">
+          <h3>Roast Pork Banh Mi</h3>
+          <span class="gallery-card__price">$11</span>
+        </div>
+        <p>Crispy roast pork with classic banh mi crunch.</p>
       </div>
     </article>
     <article class="gallery-card">
       <img
-        src="{{ url_for('static', filename='images/inspiration/streetfood-6.jpg') }}"
-        alt="Vietnamese grilled meat over open flame"
+        src="{{ url_for('static', filename='images/menu/items/chicken-sizzling-hot-plate.jpg') }}"
+        alt="Chicken sizzling hot plate with egg"
       />
       <div class="gallery-card__body">
-        <span class="gallery-card__tag">Your image</span>
-        <h3>Charcoal Grill Heat</h3>
-        <p>This adds real night-stall intensity and gives the homepage a hotter, more energetic food-street feeling.</p>
+        <div class="gallery-card__title-row">
+          <h3>Chicken Sizzling Hot Plate</h3>
+          <span class="gallery-card__price">$15</span>
+        </div>
+        <p>Sizzling chicken plate with savory house sauce.</p>
       </div>
     </article>
     <article class="gallery-card">
       <img
-        src="{{ url_for('static', filename='images/inspiration/streetfood-7.jpg') }}"
-        alt="Vietnamese shrimp rice paper rolls"
+        src="{{ url_for('static', filename='images/menu/items/thai-dessert-che-thai.jpg') }}"
+        alt="Thai dessert che thai with fruits and jelly"
       />
       <div class="gallery-card__body">
-        <span class="gallery-card__tag">Your image</span>
-        <h3>Fresh Roll Texture</h3>
-        <p>Transparent rice paper and dipping sauce introduce a cleaner, cooler visual note among the hotter grill scenes.</p>
+        <div class="gallery-card__title-row">
+          <h3>Thai Dessert (Che Thai)</h3>
+          <span class="gallery-card__price">$8</span>
+        </div>
+        <p>Chilled coconut dessert with fruit and jelly.</p>
       </div>
     </article>
     <article class="gallery-card">
       <img
-        src="{{ url_for('static', filename='images/inspiration/streetfood-8.jpg') }}"
-        alt="Vietnamese banh xeo cooking and serving"
+        src="{{ url_for('static', filename='images/menu/items/milk-coffee.jpg') }}"
+        alt="Vietnamese milk coffee with ice"
       />
       <div class="gallery-card__body">
-        <span class="gallery-card__tag">Your image</span>
-        <h3>Kitchen-to-Plate Motion</h3>
-        <p>The split cooking-and-plating shot helps communicate that MCQ is both a real kitchen and a digital ordering experience.</p>
-      </div>
-    </article>
-    <article class="gallery-card">
-      <img
-        src="{{ url_for('static', filename='images/inspiration/streetfood-9.jpg') }}"
-        alt="Vietnamese skewers and fish balls street stall"
-      />
-      <div class="gallery-card__body">
-        <span class="gallery-card__tag">Your image</span>
-        <h3>Skewer Bar Variety</h3>
-        <p>Rows of skewers and snacks make the site feel fuller and more spontaneous, like browsing a real street-food lane.</p>
-      </div>
-    </article>
-    <article class="gallery-card">
-      <img
-        src="{{ url_for('static', filename='images/inspiration/streetfood-10.jpg') }}"
-        alt="Vietnamese market grill and skewer spread"
-      />
-      <div class="gallery-card__body">
-        <span class="gallery-card__tag">Your image</span>
-        <h3>Street Stall Abundance</h3>
-        <p>The dense market spread pushes the overall design closer to a lively Saigon snack counter instead of a quiet cafe layout.</p>
-      </div>
-    </article>
-    <article class="gallery-card">
-      <img
-        src="{{ url_for('static', filename='images/inspiration/noodle-bowl-unsplash.jpg') }}"
-        alt="Vietnamese noodle bowl inspiration"
-      />
-      <div class="gallery-card__body">
-        <span class="gallery-card__tag">Online source</span>
-        <h3>Bowl-Led Appetite Appeal</h3>
-        <p>A strong food close-up still matters, so the noodle bowl stays as a cleaner appetite anchor among the busier street scenes.</p>
+        <div class="gallery-card__title-row">
+          <h3>Milk Coffee</h3>
+          <span class="gallery-card__price">$8</span>
+        </div>
+        <p>Bold Vietnamese coffee with condensed milk.</p>
       </div>
     </article>
   </div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -197,20 +197,22 @@
   }
 
   .homepage-flow {
+    position: relative;
     padding: clamp(1rem, 2.2vw, 1.45rem);
     background:
-      linear-gradient(135deg, rgba(255, 252, 247, 0.98), rgba(247, 236, 219, 0.92)),
+      linear-gradient(135deg, rgba(255, 252, 247, 0.98), rgba(247, 236, 219, 0.92) 58%, rgba(231, 244, 241, 0.92)),
       #fffaf4;
-    border-color: rgba(112, 85, 66, 0.1);
+    border-color: rgba(255, 106, 19, 0.14);
+    box-shadow: 0 20px 48px rgba(53, 30, 20, 0.09);
   }
 
   .homepage-flow__header {
     position: relative;
     z-index: 1;
-    display: flex;
-    align-items: end;
-    justify-content: space-between;
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
     gap: 1rem;
+    align-items: end;
     margin-bottom: 0.95rem;
   }
 
@@ -223,9 +225,53 @@
 
   .homepage-flow__header p {
     margin: 0;
-    max-width: 42ch;
+    max-width: 50ch;
     color: var(--text-muted);
     line-height: 1.55;
+  }
+
+  .homepage-flow__actions {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+  }
+
+  .homepage-flow__quick {
+    display: inline-flex;
+    align-items: center;
+    min-height: 42px;
+    padding: 0.62rem 0.9rem;
+    border-radius: 999px;
+    text-decoration: none;
+    font-weight: 800;
+    color: #2b170d;
+    background: linear-gradient(135deg, var(--brand-gold), var(--brand-orange));
+    border: 1px solid rgba(255, 106, 19, 0.22);
+    box-shadow: 0 10px 20px rgba(255, 106, 19, 0.16);
+  }
+
+  .homepage-flow__summary {
+    position: relative;
+    z-index: 1;
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 0.55rem;
+    margin-bottom: 0.75rem;
+  }
+
+  .homepage-flow__summary span {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 38px;
+    padding: 0.5rem 0.65rem;
+    border-radius: 999px;
+    color: var(--text-main);
+    background: rgba(255, 255, 255, 0.68);
+    border: 1px solid rgba(112, 85, 66, 0.1);
+    font-weight: 800;
+    font-size: 0.82rem;
+    text-align: center;
   }
 
   .homepage-flow__grid {
@@ -249,6 +295,27 @@
     border: 1px solid rgba(112, 85, 66, 0.12);
     box-shadow: 0 12px 24px rgba(53, 30, 20, 0.06);
     transition: transform 180ms ease, box-shadow 180ms ease, border-color 180ms ease;
+  }
+
+  .homepage-flow__step::after {
+    content: "";
+    position: absolute;
+    top: 2rem;
+    right: -0.58rem;
+    width: 0.72rem;
+    height: 2px;
+    background: rgba(255, 106, 19, 0.24);
+  }
+
+  .homepage-flow__step:last-child::after {
+    content: none;
+  }
+
+  .homepage-flow__step--member {
+    background:
+      linear-gradient(180deg, rgba(255, 247, 232, 0.96), rgba(255, 236, 205, 0.9)),
+      #fff8ed;
+    border-color: rgba(255, 106, 19, 0.22);
   }
 
   .homepage-flow__step:hover,
@@ -288,6 +355,17 @@
     color: var(--brand-red);
     font-weight: 800;
     font-size: 0.84rem;
+  }
+
+  .homepage-flow__result {
+    display: inline-flex;
+    width: fit-content;
+    padding: 0.28rem 0.5rem;
+    border-radius: 999px;
+    color: var(--brand-teal);
+    background: rgba(0, 111, 116, 0.08);
+    font-size: 0.75rem;
+    font-weight: 800;
   }
 
   .homepage-flow + .street-gallery {
@@ -992,6 +1070,7 @@
     .homepage-flow__header {
       align-items: flex-start;
       text-align: left;
+      grid-template-columns: 1fr;
       margin-bottom: 0.8rem;
     }
 
@@ -1002,6 +1081,17 @@
     .homepage-flow__header p {
       max-width: none;
       line-height: 1.45;
+    }
+
+    .homepage-flow__actions,
+    .homepage-flow__quick {
+      width: 100%;
+      justify-content: center;
+    }
+
+    .homepage-flow__summary {
+      grid-template-columns: 1fr;
+      gap: 0.4rem;
     }
 
     .homepage-flow__grid {
@@ -1019,6 +1109,10 @@
       padding: 0.9rem;
       border-radius: 18px;
       scroll-snap-align: start;
+    }
+
+    .homepage-flow__step::after {
+      content: none;
     }
 
     .homepage-flow__step p {
@@ -1179,38 +1273,51 @@
     <div>
       <p class="eyebrow">Start here</p>
       <h2 id="homepage-flow-title">A quick path from membership to pickup.</h2>
+      <p>Join once, earn rewards, then move through menu, pickup, checkout, and tracking without hunting around.</p>
     </div>
-    <p>Start with an account, earn points, then move through ordering without hunting around.</p>
+    <div class="homepage-flow__actions">
+      <a class="homepage-flow__quick" href="/register">Create account</a>
+    </div>
+  </div>
+  <div class="homepage-flow__summary" aria-label="Ordering flow benefits">
+    <span>Points and rewards stay linked</span>
+    <span>Pickup choice happens before checkout</span>
+    <span>Receipts and order tracking stay easy</span>
   </div>
   <div class="homepage-flow__grid">
-    <a class="homepage-flow__step" href="/register">
+    <a class="homepage-flow__step homepage-flow__step--member" href="/register">
       <span class="homepage-flow__number">1</span>
       <h3>Join membership</h3>
-      <p>Create an account first so points, orders, and rewards stay connected.</p>
+      <p>Create an account so points, orders, and rewards stay connected.</p>
+      <span class="homepage-flow__result">Earn points</span>
       <span class="homepage-flow__meta">Register</span>
     </a>
     <a class="homepage-flow__step" href="/menu">
       <span class="homepage-flow__number">2</span>
       <h3>Pick a favorite</h3>
       <p>Open the full menu or jump into the best sellers below.</p>
+      <span class="homepage-flow__result">Save time</span>
       <span class="homepage-flow__meta">Browse menu</span>
     </a>
     <a class="homepage-flow__step" href="/menu?fulfillment=scheduled">
       <span class="homepage-flow__number">3</span>
       <h3>Choose pickup</h3>
       <p>Order now for the counter or schedule a time that fits.</p>
+      <span class="homepage-flow__result">Pick your slot</span>
       <span class="homepage-flow__meta">Instant or scheduled</span>
     </a>
     <a class="homepage-flow__step" href="/checkout">
       <span class="homepage-flow__number">4</span>
       <h3>Checkout cleanly</h3>
       <p>Confirm contact, payment, receipt, and pickup notes.</p>
+      <span class="homepage-flow__result">Get receipt</span>
       <span class="homepage-flow__meta">Checkout</span>
     </a>
     <a class="homepage-flow__step" href="/orders">
       <span class="homepage-flow__number">5</span>
       <h3>Track and save</h3>
       <p>Follow order status, repeat meals, or share a community tip.</p>
+      <span class="homepage-flow__result">Repeat faster</span>
       <span class="homepage-flow__meta">Track order</span>
     </a>
   </div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -198,35 +198,62 @@
 
   .homepage-flow {
     position: relative;
-    padding: clamp(1rem, 2.2vw, 1.45rem);
+    padding: clamp(1.05rem, 2.6vw, 1.75rem);
     background:
-      linear-gradient(135deg, rgba(255, 252, 247, 0.98), rgba(247, 236, 219, 0.92) 58%, rgba(231, 244, 241, 0.92)),
+      linear-gradient(135deg, rgba(255, 252, 247, 0.98), rgba(247, 236, 219, 0.88) 48%, rgba(223, 243, 238, 0.92)),
       #fffaf4;
     border-color: rgba(255, 106, 19, 0.14);
-    box-shadow: 0 20px 48px rgba(53, 30, 20, 0.09);
+    box-shadow: 0 24px 58px rgba(53, 30, 20, 0.11);
+    overflow: hidden;
+  }
+
+  .homepage-flow::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    background:
+      linear-gradient(90deg, rgba(27, 20, 18, 0.07), transparent 32%),
+      radial-gradient(circle at 88% 0, rgba(0, 111, 116, 0.16), transparent 18rem),
+      radial-gradient(circle at 12% 100%, rgba(255, 106, 19, 0.12), transparent 16rem);
   }
 
   .homepage-flow__header {
     position: relative;
     z-index: 1;
     display: grid;
-    grid-template-columns: minmax(0, 1fr) auto;
-    gap: 1rem;
-    align-items: end;
-    margin-bottom: 0.95rem;
+    grid-template-columns: minmax(0, 0.95fr) minmax(18rem, 0.72fr);
+    gap: clamp(1rem, 3vw, 2rem);
+    align-items: stretch;
+    margin-bottom: 1rem;
+  }
+
+  .homepage-flow__intro {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    min-height: 14rem;
+    padding: clamp(1rem, 2.5vw, 1.6rem);
+    color: var(--text-inverse);
+    background:
+      linear-gradient(135deg, rgba(32, 23, 19, 0.96), rgba(43, 31, 24, 0.9)),
+      var(--bg-deep);
+    border: 1px solid rgba(255, 216, 115, 0.18);
+    border-radius: var(--radius-lg);
+    box-shadow: 0 22px 44px rgba(32, 18, 12, 0.18);
   }
 
   .homepage-flow__header h2 {
     margin: 0.2rem 0 0;
     font-family: "Bricolage Grotesque", "Be Vietnam Pro", sans-serif;
-    font-size: clamp(1.35rem, 2.2vw, 2rem);
+    font-size: clamp(1.75rem, 3vw, 3rem);
     line-height: 1.05;
   }
 
   .homepage-flow__header p {
     margin: 0;
     max-width: 50ch;
-    color: var(--text-muted);
+    color: rgba(255, 247, 239, 0.76);
     line-height: 1.55;
   }
 
@@ -234,13 +261,15 @@
     display: flex;
     align-items: center;
     gap: 0.5rem;
+    margin-top: 1.25rem;
   }
 
   .homepage-flow__quick {
     display: inline-flex;
     align-items: center;
+    justify-content: center;
     min-height: 42px;
-    padding: 0.62rem 0.9rem;
+    padding: 0.68rem 1rem;
     border-radius: 999px;
     text-decoration: none;
     font-weight: 800;
@@ -250,28 +279,86 @@
     box-shadow: 0 10px 20px rgba(255, 106, 19, 0.16);
   }
 
+  .homepage-flow__quick:hover,
+  .homepage-flow__quick:focus-visible {
+    transform: translateY(-1px);
+    box-shadow: 0 14px 26px rgba(255, 106, 19, 0.22);
+    outline: 0;
+  }
+
+  .homepage-flow__quick--ghost {
+    color: var(--text-inverse);
+    background: rgba(255, 255, 255, 0.09);
+    border-color: rgba(255, 247, 239, 0.22);
+    box-shadow: none;
+  }
+
+  .homepage-flow__quick--ghost:hover,
+  .homepage-flow__quick--ghost:focus-visible {
+    border-color: rgba(255, 216, 115, 0.42);
+    box-shadow: 0 14px 26px rgba(0, 0, 0, 0.12);
+  }
+
+  .homepage-flow__visual {
+    position: relative;
+    min-height: 14rem;
+    display: grid;
+    align-content: end;
+    overflow: hidden;
+    border-radius: var(--radius-lg);
+    background:
+      linear-gradient(180deg, transparent 22%, rgba(27, 20, 18, 0.72)),
+      url("{{ url_for('static', filename='images/inspiration/saigon-market-night.jpg') }}") center/cover;
+    border: 1px solid rgba(112, 85, 66, 0.12);
+    box-shadow: 0 18px 42px rgba(53, 30, 20, 0.12);
+  }
+
+  .homepage-flow__visual-copy {
+    position: relative;
+    z-index: 1;
+    display: grid;
+    gap: 0.35rem;
+    padding: 1rem;
+    color: var(--text-inverse);
+  }
+
+  .homepage-flow__visual-copy span {
+    color: var(--brand-gold);
+    font-size: 0.78rem;
+    font-weight: 900;
+    text-transform: uppercase;
+  }
+
+  .homepage-flow__visual-copy strong {
+    max-width: 21rem;
+    font-family: "Bricolage Grotesque", "Be Vietnam Pro", sans-serif;
+    font-size: clamp(1.1rem, 2vw, 1.65rem);
+    line-height: 1.08;
+  }
+
   .homepage-flow__summary {
     position: relative;
     z-index: 1;
     display: grid;
     grid-template-columns: repeat(3, minmax(0, 1fr));
-    gap: 0.55rem;
-    margin-bottom: 0.75rem;
+    gap: 0.65rem;
+    margin-bottom: 0.9rem;
   }
 
   .homepage-flow__summary span {
     display: inline-flex;
     align-items: center;
-    justify-content: center;
-    min-height: 38px;
-    padding: 0.5rem 0.65rem;
-    border-radius: 999px;
+    justify-content: flex-start;
+    min-height: 3.5rem;
+    padding: 0.72rem 0.85rem;
+    border-radius: 18px;
     color: var(--text-main);
-    background: rgba(255, 255, 255, 0.68);
+    background: rgba(255, 255, 255, 0.72);
     border: 1px solid rgba(112, 85, 66, 0.1);
     font-weight: 800;
     font-size: 0.82rem;
-    text-align: center;
+    text-align: left;
+    box-shadow: 0 10px 22px rgba(53, 30, 20, 0.05);
   }
 
   .homepage-flow__grid {
@@ -279,62 +366,69 @@
     z-index: 1;
     display: grid;
     grid-template-columns: repeat(5, minmax(0, 1fr));
-    gap: 0.75rem;
+    gap: 0.8rem;
+  }
+
+  .homepage-flow__grid::before {
+    content: "";
+    position: absolute;
+    top: 2.05rem;
+    left: 1.4rem;
+    right: 1.4rem;
+    height: 3px;
+    border-radius: 999px;
+    background: linear-gradient(90deg, var(--brand-orange), var(--brand-gold), var(--brand-teal));
+    opacity: 0.38;
   }
 
   .homepage-flow__step {
     position: relative;
     display: grid;
     gap: 0.45rem;
-    min-height: 9.2rem;
-    padding: 0.92rem;
-    border-radius: 22px;
+    min-height: 10.5rem;
+    padding: 0.95rem;
+    border-radius: 20px;
     text-decoration: none;
     color: inherit;
-    background: rgba(255, 255, 255, 0.76);
+    background:
+      linear-gradient(180deg, rgba(255, 255, 255, 0.94), rgba(255, 250, 243, 0.82)),
+      rgba(255, 255, 255, 0.82);
     border: 1px solid rgba(112, 85, 66, 0.12);
-    box-shadow: 0 12px 24px rgba(53, 30, 20, 0.06);
+    box-shadow: 0 15px 30px rgba(53, 30, 20, 0.07);
     transition: transform 180ms ease, box-shadow 180ms ease, border-color 180ms ease;
   }
 
   .homepage-flow__step::after {
-    content: "";
-    position: absolute;
-    top: 2rem;
-    right: -0.58rem;
-    width: 0.72rem;
-    height: 2px;
-    background: rgba(255, 106, 19, 0.24);
-  }
-
-  .homepage-flow__step:last-child::after {
     content: none;
   }
 
   .homepage-flow__step--member {
     background:
-      linear-gradient(180deg, rgba(255, 247, 232, 0.96), rgba(255, 236, 205, 0.9)),
-      #fff8ed;
-    border-color: rgba(255, 106, 19, 0.22);
+      linear-gradient(180deg, rgba(255, 245, 224, 0.98), rgba(255, 231, 190, 0.9)),
+      #fff4df;
+    border-color: rgba(255, 106, 19, 0.28);
   }
 
   .homepage-flow__step:hover,
   .homepage-flow__step:focus-visible {
-    transform: translateY(-2px);
-    border-color: rgba(255, 106, 19, 0.26);
-    box-shadow: 0 16px 30px rgba(53, 30, 20, 0.1);
+    transform: translateY(-4px);
+    border-color: rgba(0, 111, 116, 0.24);
+    box-shadow: 0 22px 38px rgba(53, 30, 20, 0.13);
     outline: 0;
   }
 
   .homepage-flow__number {
     display: inline-grid;
     place-items: center;
-    width: 2rem;
-    height: 2rem;
+    width: 2.2rem;
+    height: 2.2rem;
     border-radius: 999px;
     font-weight: 800;
     color: #2b170d;
     background: linear-gradient(135deg, var(--brand-gold), var(--brand-orange));
+    box-shadow:
+      0 0 0 6px rgba(255, 255, 255, 0.78),
+      0 10px 18px rgba(255, 106, 19, 0.18);
   }
 
   .homepage-flow__step h3 {
@@ -1047,6 +1141,15 @@
     .landing-hero--minimal .button-row {
       justify-content: center;
     }
+
+    .homepage-flow__header {
+      grid-template-columns: 1fr;
+    }
+
+    .homepage-flow__intro,
+    .homepage-flow__visual {
+      min-height: 12.5rem;
+    }
   }
 
   @media (max-width: 720px) {
@@ -1074,6 +1177,16 @@
       margin-bottom: 0.8rem;
     }
 
+    .homepage-flow__intro {
+      padding: 1rem;
+      border-radius: 20px;
+    }
+
+    .homepage-flow__visual {
+      min-height: 11rem;
+      border-radius: 20px;
+    }
+
     .homepage-flow__header h2 {
       font-size: 1.45rem;
     }
@@ -1086,6 +1199,13 @@
     .homepage-flow__actions,
     .homepage-flow__quick {
       width: 100%;
+    }
+
+    .homepage-flow__actions {
+      flex-direction: column;
+    }
+
+    .homepage-flow__quick {
       justify-content: center;
     }
 
@@ -1102,6 +1222,10 @@
       overflow-x: auto;
       padding-bottom: 0.35rem;
       scroll-snap-type: x proximity;
+    }
+
+    .homepage-flow__grid::before {
+      content: none;
     }
 
     .homepage-flow__step {
@@ -1270,13 +1394,20 @@
 
 <section class="homepage-flow section-panel" aria-labelledby="homepage-flow-title">
   <div class="homepage-flow__header">
-    <div>
+    <div class="homepage-flow__intro">
       <p class="eyebrow">Start here</p>
       <h2 id="homepage-flow-title">A quick path from membership to pickup.</h2>
       <p>Join once, earn rewards, then move through menu, pickup, checkout, and tracking without hunting around.</p>
+      <div class="homepage-flow__actions">
+        <a class="homepage-flow__quick" href="/register">Create account</a>
+        <a class="homepage-flow__quick homepage-flow__quick--ghost" href="/community">Join MCQ Community</a>
+      </div>
     </div>
-    <div class="homepage-flow__actions">
-      <a class="homepage-flow__quick" href="/register">Create account</a>
+    <div class="homepage-flow__visual" aria-hidden="true">
+      <div class="homepage-flow__visual-copy">
+        <span>Street-to-counter flow</span>
+        <strong>From first craving to receipt, every step feels like one MCQ journey.</strong>
+      </div>
     </div>
   </div>
   <div class="homepage-flow__summary" aria-label="Ordering flow benefits">

--- a/templates/index.html
+++ b/templates/index.html
@@ -232,7 +232,7 @@
     position: relative;
     z-index: 1;
     display: grid;
-    grid-template-columns: repeat(4, minmax(0, 1fr));
+    grid-template-columns: repeat(5, minmax(0, 1fr));
     gap: 0.75rem;
   }
 
@@ -240,8 +240,8 @@
     position: relative;
     display: grid;
     gap: 0.45rem;
-    min-height: 9.4rem;
-    padding: 1rem;
+    min-height: 9.2rem;
+    padding: 0.92rem;
     border-radius: 22px;
     text-decoration: none;
     color: inherit;
@@ -273,7 +273,7 @@
   .homepage-flow__step h3 {
     margin: 0.15rem 0 0;
     font-family: "Bricolage Grotesque", "Be Vietnam Pro", sans-serif;
-    font-size: 1.08rem;
+    font-size: 1.02rem;
   }
 
   .homepage-flow__step p {
@@ -918,9 +918,12 @@
   }
 
   @media (max-width: 1180px) {
-    .homepage-flow__grid,
     .launchpad__grid {
       grid-template-columns: repeat(2, minmax(0, 1fr));
+    }
+
+    .homepage-flow__grid {
+      grid-template-columns: repeat(3, minmax(0, 1fr));
     }
   }
 
@@ -1175,31 +1178,37 @@
   <div class="homepage-flow__header">
     <div>
       <p class="eyebrow">Start here</p>
-      <h2 id="homepage-flow-title">A quick path from craving to pickup.</h2>
+      <h2 id="homepage-flow-title">A quick path from membership to pickup.</h2>
     </div>
-    <p>Move through the site in a simple order, with the main actions kept close to the top.</p>
+    <p>Start with an account, earn points, then move through ordering without hunting around.</p>
   </div>
   <div class="homepage-flow__grid">
-    <a class="homepage-flow__step" href="/menu">
+    <a class="homepage-flow__step" href="/register">
       <span class="homepage-flow__number">1</span>
+      <h3>Join membership</h3>
+      <p>Create an account first so points, orders, and rewards stay connected.</p>
+      <span class="homepage-flow__meta">Register</span>
+    </a>
+    <a class="homepage-flow__step" href="/menu">
+      <span class="homepage-flow__number">2</span>
       <h3>Pick a favorite</h3>
       <p>Open the full menu or jump into the best sellers below.</p>
       <span class="homepage-flow__meta">Browse menu</span>
     </a>
     <a class="homepage-flow__step" href="/menu?fulfillment=scheduled">
-      <span class="homepage-flow__number">2</span>
+      <span class="homepage-flow__number">3</span>
       <h3>Choose pickup</h3>
       <p>Order now for the counter or schedule a time that fits.</p>
       <span class="homepage-flow__meta">Instant or scheduled</span>
     </a>
     <a class="homepage-flow__step" href="/checkout">
-      <span class="homepage-flow__number">3</span>
+      <span class="homepage-flow__number">4</span>
       <h3>Checkout cleanly</h3>
       <p>Confirm contact, payment, receipt, and pickup notes.</p>
       <span class="homepage-flow__meta">Checkout</span>
     </a>
     <a class="homepage-flow__step" href="/orders">
-      <span class="homepage-flow__number">4</span>
+      <span class="homepage-flow__number">5</span>
       <h3>Track and save</h3>
       <p>Follow order status, repeat meals, or share a community tip.</p>
       <span class="homepage-flow__meta">Track order</span>

--- a/templates/index.html
+++ b/templates/index.html
@@ -462,23 +462,43 @@
   }
 
   .street-gallery__control {
-    width: 44px;
-    height: 44px;
-    border: 1px solid rgba(112, 85, 66, 0.2);
-    border-radius: 999px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 36px;
+    height: 36px;
+    border: 1.5px solid rgba(112, 85, 66, 0.18);
+    border-radius: 10px;
     font: inherit;
-    font-size: 1.2rem;
-    font-weight: 800;
-    color: #28170f;
-    background: rgba(255, 255, 255, 0.94);
-    box-shadow: 0 10px 18px rgba(53, 30, 20, 0.12);
+    font-size: 0;
+    color: #3d2518;
+    background: rgba(255, 255, 255, 0.92);
+    backdrop-filter: blur(6px);
+    box-shadow: 0 2px 8px rgba(53, 30, 20, 0.08);
     cursor: pointer;
-    transition: transform 160ms ease, box-shadow 220ms ease;
+    transition: background 180ms ease, border-color 180ms ease, transform 140ms ease, box-shadow 180ms ease;
   }
 
   .street-gallery__control:hover {
+    background: rgba(235, 81, 48, 0.08);
+    border-color: rgba(235, 81, 48, 0.4);
     transform: translateY(-1px);
-    box-shadow: 0 14px 22px rgba(53, 30, 20, 0.16);
+    box-shadow: 0 4px 12px rgba(235, 81, 48, 0.12);
+  }
+
+  .street-gallery__control:active {
+    transform: scale(0.94);
+    box-shadow: 0 1px 4px rgba(53, 30, 20, 0.1);
+  }
+
+  .street-gallery__control svg {
+    width: 18px;
+    height: 18px;
+    stroke: currentColor;
+    stroke-width: 2.2;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+    fill: none;
   }
 
   .street-gallery__rail {
@@ -521,11 +541,23 @@
   .gallery-card {
     width: min(270px, calc(100vw - 3.2rem));
     overflow: hidden;
-    border-radius: 14px;
-    border: 1px solid rgba(53, 30, 20, 0.35);
-    background: #fbf7ee;
-    box-shadow: 0 10px 24px rgba(53, 30, 20, 0.08);
+    border-radius: var(--radius-xl, 18px);
+    border: 1px solid var(--line-soft, rgba(112, 85, 66, 0.12));
+    background:
+      linear-gradient(180deg, rgba(255, 252, 247, 0.98), rgba(248, 236, 220, 0.94)),
+      #fff;
+    box-shadow:
+      0 18px 36px rgba(53, 30, 20, 0.07),
+      0 0 0 1px rgba(255, 255, 255, 0.6) inset;
     scroll-snap-align: start;
+    transition: transform 280ms ease, box-shadow 280ms ease;
+  }
+
+  .gallery-card:hover {
+    transform: translateY(-3px);
+    box-shadow:
+      0 24px 44px rgba(53, 30, 20, 0.11),
+      0 0 0 1px rgba(255, 255, 255, 0.7) inset;
   }
 
   .gallery-card img {
@@ -534,12 +566,11 @@
     object-fit: cover;
     object-position: center;
     display: block;
+    border-bottom: 1px solid rgba(112, 85, 66, 0.1);
   }
 
   .gallery-card__body {
-    padding: 0.8rem 0.86rem 0.9rem;
-    background: #fbf7ee;
-    border-top: 1px solid rgba(53, 30, 20, 0.22);
+    padding: 0.85rem 0.95rem 1rem;
     display: block;
   }
 
@@ -559,9 +590,13 @@
   }
 
   .gallery-card__price {
-    font-size: 0.96rem;
+    font-size: 0.82rem;
     font-weight: 700;
     color: var(--brand-red);
+    background: rgba(255, 106, 19, 0.09);
+    padding: 0.18rem 0.5rem;
+    border-radius: 999px;
+    border: 1px solid rgba(255, 180, 54, 0.2);
     white-space: nowrap;
   }
 
@@ -694,13 +729,40 @@
     }
 
     .street-gallery__controls {
-      width: 100%;
-      justify-content: space-between;
+      width: auto;
+      justify-content: flex-end;
+      gap: 0.5rem;
+    }
+
+    .street-gallery__hint {
+      display: none;
+    }
+
+    .street-gallery__control {
+      width: 32px;
+      height: 32px;
+      border-radius: 8px;
+    }
+
+    .street-gallery__control svg {
+      width: 16px;
+      height: 16px;
+    }
+
+    .street-gallery__rail {
+      margin-left: 0;
+      margin-right: 0;
+      padding-left: 0;
+      padding-right: 0;
     }
 
     .street-gallery__grid {
       gap: 0.75rem;
-      grid-auto-columns: minmax(78vw, 260px);
+      grid-auto-columns: minmax(200px, 240px);
+    }
+
+    .gallery-card {
+      width: 240px;
     }
 
     .street-gallery {
@@ -763,7 +825,7 @@
         data-gallery-shift="-1"
         aria-label="Scroll best sellers left"
       >
-        &larr;
+        <svg viewBox="0 0 24 24"><polyline points="15 18 9 12 15 6"/></svg>
       </button>
       <button
         class="street-gallery__control"
@@ -771,7 +833,7 @@
         data-gallery-shift="1"
         aria-label="Scroll best sellers right"
       >
-        &rarr;
+        <svg viewBox="0 0 24 24"><polyline points="9 6 15 12 9 18"/></svg>
       </button>
     </div>
   </div>

--- a/templates/index.html
+++ b/templates/index.html
@@ -196,6 +196,100 @@
     display: block;
   }
 
+  .homepage-flow {
+    padding: clamp(1rem, 2.2vw, 1.45rem);
+    background:
+      linear-gradient(135deg, rgba(255, 252, 247, 0.98), rgba(247, 236, 219, 0.92)),
+      #fffaf4;
+    border-color: rgba(112, 85, 66, 0.1);
+  }
+
+  .homepage-flow__header {
+    position: relative;
+    z-index: 1;
+    display: flex;
+    align-items: end;
+    justify-content: space-between;
+    gap: 1rem;
+    margin-bottom: 0.95rem;
+  }
+
+  .homepage-flow__header h2 {
+    margin: 0.2rem 0 0;
+    font-family: "Bricolage Grotesque", "Be Vietnam Pro", sans-serif;
+    font-size: clamp(1.35rem, 2.2vw, 2rem);
+    line-height: 1.05;
+  }
+
+  .homepage-flow__header p {
+    margin: 0;
+    max-width: 42ch;
+    color: var(--text-muted);
+    line-height: 1.55;
+  }
+
+  .homepage-flow__grid {
+    position: relative;
+    z-index: 1;
+    display: grid;
+    grid-template-columns: repeat(4, minmax(0, 1fr));
+    gap: 0.75rem;
+  }
+
+  .homepage-flow__step {
+    position: relative;
+    display: grid;
+    gap: 0.45rem;
+    min-height: 9.4rem;
+    padding: 1rem;
+    border-radius: 22px;
+    text-decoration: none;
+    color: inherit;
+    background: rgba(255, 255, 255, 0.76);
+    border: 1px solid rgba(112, 85, 66, 0.12);
+    box-shadow: 0 12px 24px rgba(53, 30, 20, 0.06);
+    transition: transform 180ms ease, box-shadow 180ms ease, border-color 180ms ease;
+  }
+
+  .homepage-flow__step:hover,
+  .homepage-flow__step:focus-visible {
+    transform: translateY(-2px);
+    border-color: rgba(255, 106, 19, 0.26);
+    box-shadow: 0 16px 30px rgba(53, 30, 20, 0.1);
+    outline: 0;
+  }
+
+  .homepage-flow__number {
+    display: inline-grid;
+    place-items: center;
+    width: 2rem;
+    height: 2rem;
+    border-radius: 999px;
+    font-weight: 800;
+    color: #2b170d;
+    background: linear-gradient(135deg, var(--brand-gold), var(--brand-orange));
+  }
+
+  .homepage-flow__step h3 {
+    margin: 0.15rem 0 0;
+    font-family: "Bricolage Grotesque", "Be Vietnam Pro", sans-serif;
+    font-size: 1.08rem;
+  }
+
+  .homepage-flow__step p {
+    margin: 0;
+    color: var(--text-muted);
+    line-height: 1.45;
+    font-size: 0.92rem;
+  }
+
+  .homepage-flow__meta {
+    margin-top: auto;
+    color: var(--brand-red);
+    font-weight: 800;
+    font-size: 0.84rem;
+  }
+
   .launchpad__header,
   .support-story__copy,
   .support-story__panel {
@@ -1031,6 +1125,42 @@
         />
       </div>
     </figure>
+  </div>
+</section>
+
+<section class="homepage-flow section-panel" aria-labelledby="homepage-flow-title">
+  <div class="homepage-flow__header">
+    <div>
+      <p class="eyebrow">Start here</p>
+      <h2 id="homepage-flow-title">A quick path from craving to pickup.</h2>
+    </div>
+    <p>Move through the site in a simple order, with the main actions kept close to the top.</p>
+  </div>
+  <div class="homepage-flow__grid">
+    <a class="homepage-flow__step" href="/menu">
+      <span class="homepage-flow__number">1</span>
+      <h3>Pick a favorite</h3>
+      <p>Open the full menu or jump into the best sellers below.</p>
+      <span class="homepage-flow__meta">Browse menu</span>
+    </a>
+    <a class="homepage-flow__step" href="/menu?fulfillment=instant">
+      <span class="homepage-flow__number">2</span>
+      <h3>Choose pickup</h3>
+      <p>Order now for the counter or schedule a time that fits.</p>
+      <span class="homepage-flow__meta">Instant or scheduled</span>
+    </a>
+    <a class="homepage-flow__step" href="/checkout">
+      <span class="homepage-flow__number">3</span>
+      <h3>Checkout cleanly</h3>
+      <p>Confirm contact, payment, receipt, and pickup notes.</p>
+      <span class="homepage-flow__meta">Checkout</span>
+    </a>
+    <a class="homepage-flow__step" href="/orders">
+      <span class="homepage-flow__number">4</span>
+      <h3>Track and save</h3>
+      <p>Follow order status, repeat meals, or share a community tip.</p>
+      <span class="homepage-flow__meta">Track order</span>
+    </a>
   </div>
 </section>
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -512,22 +512,11 @@
     padding-right: max(0.35rem, env(safe-area-inset-right));
     scroll-behavior: smooth;
     scroll-snap-type: x proximity;
-    scrollbar-width: thin;
-    scrollbar-color: rgba(235, 81, 48, 0.5) rgba(112, 85, 66, 0.08);
+    scrollbar-width: none;
   }
 
   .street-gallery__rail::-webkit-scrollbar {
-    height: 10px;
-  }
-
-  .street-gallery__rail::-webkit-scrollbar-track {
-    background: rgba(112, 85, 66, 0.08);
-    border-radius: 999px;
-  }
-
-  .street-gallery__rail::-webkit-scrollbar-thumb {
-    background: linear-gradient(135deg, var(--brand-orange), var(--brand-red));
-    border-radius: 999px;
+    display: none;
   }
 
   .street-gallery__grid {
@@ -544,23 +533,16 @@
     overflow: hidden;
     border-radius: var(--radius-xl, 18px);
     border: 1px solid var(--line-soft, rgba(112, 85, 66, 0.12));
-    background:
-      linear-gradient(180deg, rgba(255, 252, 247, 0.98), rgba(248, 236, 220, 0.94)),
-      #fff;
-    box-shadow:
-      0 18px 36px rgba(53, 30, 20, 0.07),
-      0 0 0 1px rgba(255, 255, 255, 0.6) inset;
+    background: #fef4e8;
+    box-shadow: none;
     scroll-snap-align: start;
-    transition: transform 280ms ease, box-shadow 280ms ease;
     color: inherit;
     text-decoration: none;
+    transition: background 220ms ease;
   }
 
   .gallery-card:hover {
-    transform: translateY(-3px);
-    box-shadow:
-      0 24px 44px rgba(53, 30, 20, 0.11),
-      0 0 0 1px rgba(255, 255, 255, 0.7) inset;
+    background: #fde9cf;
   }
 
   .gallery-card img {

--- a/templates/index.html
+++ b/templates/index.html
@@ -539,6 +539,7 @@
   }
 
   .gallery-card {
+    display: block;
     width: min(270px, calc(100vw - 3.2rem));
     overflow: hidden;
     border-radius: var(--radius-xl, 18px);
@@ -551,6 +552,8 @@
       0 0 0 1px rgba(255, 255, 255, 0.6) inset;
     scroll-snap-align: start;
     transition: transform 280ms ease, box-shadow 280ms ease;
+    color: inherit;
+    text-decoration: none;
   }
 
   .gallery-card:hover {
@@ -839,7 +842,7 @@
   </div>
   <div class="street-gallery__rail" id="street-gallery-rail">
   <div class="street-gallery__grid">
-    <article class="gallery-card">
+    <a class="gallery-card" href="/menu/item/pho-noodle-soup__mcq-special-pho">
       <img src="{{ url_for('static', filename='images/menu/items/mcq-special-pho.jpg') }}" alt="MCQ Special Pho in broth with herbs" />
       <div class="gallery-card__body">
         <div class="gallery-card__title-row">
@@ -848,8 +851,8 @@
         </div>
         <p>Signature mixed-beef pho with rich broth.</p>
       </div>
-    </article>
-    <article class="gallery-card">
+    </a>
+    <a class="gallery-card" href="/menu/item/pho-noodle-soup__slow-cooked-beef-rib-pho">
       <img
         src="{{ url_for('static', filename='images/menu/items/slow-cooked-beef-rib-pho.jpg') }}"
         alt="Slow-cooked beef rib pho with fresh garnish"
@@ -861,8 +864,8 @@
         </div>
         <p>Deep, slow-simmered broth with tender rib.</p>
       </div>
-    </article>
-    <article class="gallery-card">
+    </a>
+    <a class="gallery-card" href="/menu/item/rice-dishes__grilled-pork-chop-with-broken-rice">
       <img
         src="{{ url_for('static', filename='images/menu/items/grilled-pork-chop-with-broken-rice.jpg') }}"
         alt="Grilled pork chop with broken rice and sides"
@@ -874,8 +877,8 @@
         </div>
         <p>Classic lunch plate with full savory sides.</p>
       </div>
-    </article>
-    <article class="gallery-card">
+    </a>
+    <a class="gallery-card" href="/menu/item/mcq-sizzling-hot-plates__mcq-sizzling-beef-with-bread">
       <img
         src="{{ url_for('static', filename='images/menu/items/mcq-sizzling-beef-with-bread.jpg') }}"
         alt="Sizzling beef with bread and sunny side egg"
@@ -887,8 +890,8 @@
         </div>
         <p>Hotplate favorite with steak, egg, and bread.</p>
       </div>
-    </article>
-    <article class="gallery-card">
+    </a>
+    <a class="gallery-card" href="/menu/item/banh-mi__roast-pork-b-nh-m">
       <img
         src="{{ url_for('static', filename='images/menu/items/roast-pork-banh-mi.jpg') }}"
         alt="Roast pork banh mi on crusty bread"
@@ -900,8 +903,8 @@
         </div>
         <p>Crispy roast pork with classic banh mi crunch.</p>
       </div>
-    </article>
-    <article class="gallery-card">
+    </a>
+    <a class="gallery-card" href="/menu/item/mcq-sizzling-hot-plates__chicken-sizzling-hot-plate">
       <img
         src="{{ url_for('static', filename='images/menu/items/chicken-sizzling-hot-plate.jpg') }}"
         alt="Chicken sizzling hot plate with egg"
@@ -913,8 +916,8 @@
         </div>
         <p>Sizzling chicken plate with savory house sauce.</p>
       </div>
-    </article>
-    <article class="gallery-card">
+    </a>
+    <a class="gallery-card" href="/menu/item/desserts__thai-dessert-che-thai">
       <img
         src="{{ url_for('static', filename='images/menu/items/thai-dessert-che-thai.jpg') }}"
         alt="Thai dessert che thai with fruits and jelly"
@@ -926,8 +929,8 @@
         </div>
         <p>Chilled coconut dessert with fruit and jelly.</p>
       </div>
-    </article>
-    <article class="gallery-card">
+    </a>
+    <a class="gallery-card" href="/menu/item/vietnamese-coffee__milk-coffee">
       <img
         src="{{ url_for('static', filename='images/menu/items/milk-coffee.jpg') }}"
         alt="Vietnamese milk coffee with ice"
@@ -939,7 +942,7 @@
         </div>
         <p>Bold Vietnamese coffee with condensed milk.</p>
       </div>
-    </article>
+    </a>
   </div>
   </div>
 </section>

--- a/templates/index.html
+++ b/templates/index.html
@@ -690,144 +690,6 @@
   </div>
 </section>
 
-<section class="live-ops section-panel" id="live-ordering">
-  <div class="live-ops__grid">
-    <div>
-      <p class="eyebrow">Live ordering status</p>
-      <h2 class="section-title">Realtime queue and pickup availability</h2>
-      <p class="section-copy">
-        These widgets reflect the current queue load and scheduled pickup planner, so customers know whether to order now
-        or move to a booked slot before they reach checkout.
-      </p>
-      <div class="live-ops__stats">
-        <article class="live-ops__card">
-          <strong>{{ ordering_snapshot.instant_queue.active_count }}/{{ ordering_snapshot.instant_queue.max_active_orders }}</strong>
-          <span>
-            Active instant orders at {{ ordering_snapshot.instant_queue.counter_label }}.
-            Next live ticket is #{{ "%03d"|format(ordering_snapshot.instant_queue.next_queue_number) }}.
-          </span>
-        </article>
-        <article class="live-ops__card">
-          <strong>{{ ordering_snapshot.instant_queue.quoted_wait_minutes }} min</strong>
-          <span>
-            Current instant ETA baseline from {{ ordering_snapshot.instant_queue.kitchen_active_count }} kitchen-active order(s)
-            {% if ordering_snapshot.instant_queue.can_accept %}, ready around {{ ordering_snapshot.instant_queue.estimated_ready_label }}{% endif %}.
-          </span>
-        </article>
-        <article class="live-ops__card">
-          <strong>
-            {% if ordering_snapshot.next_available_pickup %}
-              {{ ordering_snapshot.next_available_pickup.time_label }}
-            {% else %}
-              Unavailable
-            {% endif %}
-          </strong>
-          <span>
-            {% if ordering_snapshot.next_available_pickup %}
-              Next scheduled slot on {{ ordering_snapshot.next_available_pickup.date_label }}.
-            {% else %}
-              No scheduled slots are currently open.
-            {% endif %}
-          </span>
-        </article>
-      </div>
-    </div>
-
-    <aside class="tracker-card">
-      <div class="tracker-card__stack">
-        <div>
-          <p class="eyebrow">Track order</p>
-          <h2>Open detail or receipt directly</h2>
-          <p class="section-copy">Enter the order number from the receipt to jump straight into live tracking.</p>
-        </div>
-        {% if track_error %}
-          <div class="tracker-error">{{ track_error }}</div>
-        {% endif %}
-        <form method="post" action="{{ url_for('public.track_order') }}" class="tracker-form">
-          <div class="tracker-field">
-            <label for="order_number">Order number</label>
-            <input id="order_number" name="order_number" type="text" value="{{ track_value }}" placeholder="MCQ-20260414-AB12" />
-          </div>
-          <div class="tracker-field">
-            <label for="destination">Open</label>
-            <select id="destination" name="destination">
-              <option value="detail">Order detail</option>
-              <option value="receipt">Receipt</option>
-            </select>
-          </div>
-          <button type="submit" class="button button--primary">Track Order</button>
-        </form>
-        <div class="tracker-note">
-          <strong>{{ ordering_snapshot.ready_count }} ready now</strong>
-          <p>Orders already marked ready for pickup are surfaced across the site through in-app notifications.</p>
-        </div>
-      </div>
-    </aside>
-  </div>
-</section>
-
-<section class="launchpad section-panel">
-  <div class="launchpad__header">
-    <div>
-      <p class="eyebrow">User-side launchpad</p>
-      <h2>Buttons ready for the feature set in the README</h2>
-    </div>
-    <p>
-      The homepage now exposes the planned customer journey more clearly: account setup, menu browsing, cart,
-      instant ordering, scheduled pickup, checkout, receipt, live order tracking, and support.
-    </p>
-  </div>
-  <div class="launchpad__grid">
-    <article class="launch-card">
-      <p class="launch-card__kicker">Account</p>
-      <h3>Get customers in fast</h3>
-      <p>Keep account entry simple so returning customers can sign in quickly before placing or tracking an order.</p>
-      <div class="launch-card__actions">
-        <a class="feature-button feature-button--accent" href="/register">Register</a>
-        <a class="feature-button" href="/login">Login</a>
-      </div>
-    </article>
-    <article class="launch-card">
-      <p class="launch-card__kicker">Ordering</p>
-      <h3>Cover both ordering paths</h3>
-      <p>These buttons map directly to the two real customer journeys and both start in the menu, where customers choose dishes first.</p>
-      <div class="launch-card__actions">
-        <a class="feature-button feature-button--accent" href="/menu?fulfillment=instant">Instant Menu</a>
-        <a class="feature-button" href="/menu?fulfillment=scheduled">Scheduled Menu</a>
-        <a class="feature-button" href="/cart?fulfillment=instant">Cart</a>
-      </div>
-    </article>
-    <article class="launch-card">
-      <p class="launch-card__kicker">Checkout Flow</p>
-      <h3>Keep the next step obvious</h3>
-      <p>Once dishes are in the cart, customers can move into instant checkout, scheduled pickup planning, or order history without detours.</p>
-      <div class="launch-card__actions">
-        <a class="feature-button feature-button--accent" href="/checkout?fulfillment=instant">Instant Checkout</a>
-        <a class="feature-button" href="/pickup-planner?fulfillment=scheduled">Scheduled Pickup</a>
-        <a class="feature-button" href="/orders">Order History</a>
-      </div>
-    </article>
-    <article class="launch-card">
-      <p class="launch-card__kicker">Tracking</p>
-      <h3>Receipts and live updates</h3>
-      <p>Customers can jump back into tracking, receipt lookup, and live pickup notifications from one clear section.</p>
-      <div class="launch-card__actions">
-        <a class="feature-button feature-button--accent" href="/orders">Open Orders</a>
-        <a class="feature-button" href="#live-ordering">Track by Order Number</a>
-      </div>
-    </article>
-    <article class="launch-card">
-      <p class="launch-card__kicker">Support</p>
-      <h3>Help is always nearby</h3>
-      <p>The floating chatbox and phone contact keep help visible without interrupting the main ordering path.</p>
-      <div class="launch-card__actions">
-        <a class="feature-button feature-button--accent" href="tel:+61892485623">Call 08 9248 5623</a>
-        <a class="feature-button" href="tel:+61892485623">08 9248 5623</a>
-      </div>
-    </article>
-  </div>
-</section>
-
 <section class="street-gallery section-panel">
   <div class="street-gallery__header">
     <div class="street-gallery__header-copy">
@@ -979,6 +841,144 @@
       </div>
     </article>
   </div>
+  </div>
+</section>
+
+<section class="live-ops section-panel" id="live-ordering">
+  <div class="live-ops__grid">
+    <div>
+      <p class="eyebrow">Live ordering status</p>
+      <h2 class="section-title">Realtime queue and pickup availability</h2>
+      <p class="section-copy">
+        These widgets reflect the current queue load and scheduled pickup planner, so customers know whether to order now
+        or move to a booked slot before they reach checkout.
+      </p>
+      <div class="live-ops__stats">
+        <article class="live-ops__card">
+          <strong>{{ ordering_snapshot.instant_queue.active_count }}/{{ ordering_snapshot.instant_queue.max_active_orders }}</strong>
+          <span>
+            Active instant orders at {{ ordering_snapshot.instant_queue.counter_label }}.
+            Next live ticket is #{{ "%03d"|format(ordering_snapshot.instant_queue.next_queue_number) }}.
+          </span>
+        </article>
+        <article class="live-ops__card">
+          <strong>{{ ordering_snapshot.instant_queue.quoted_wait_minutes }} min</strong>
+          <span>
+            Current instant ETA baseline from {{ ordering_snapshot.instant_queue.kitchen_active_count }} kitchen-active order(s)
+            {% if ordering_snapshot.instant_queue.can_accept %}, ready around {{ ordering_snapshot.instant_queue.estimated_ready_label }}{% endif %}.
+          </span>
+        </article>
+        <article class="live-ops__card">
+          <strong>
+            {% if ordering_snapshot.next_available_pickup %}
+              {{ ordering_snapshot.next_available_pickup.time_label }}
+            {% else %}
+              Unavailable
+            {% endif %}
+          </strong>
+          <span>
+            {% if ordering_snapshot.next_available_pickup %}
+              Next scheduled slot on {{ ordering_snapshot.next_available_pickup.date_label }}.
+            {% else %}
+              No scheduled slots are currently open.
+            {% endif %}
+          </span>
+        </article>
+      </div>
+    </div>
+
+    <aside class="tracker-card">
+      <div class="tracker-card__stack">
+        <div>
+          <p class="eyebrow">Track order</p>
+          <h2>Open detail or receipt directly</h2>
+          <p class="section-copy">Enter the order number from the receipt to jump straight into live tracking.</p>
+        </div>
+        {% if track_error %}
+          <div class="tracker-error">{{ track_error }}</div>
+        {% endif %}
+        <form method="post" action="{{ url_for('public.track_order') }}" class="tracker-form">
+          <div class="tracker-field">
+            <label for="order_number">Order number</label>
+            <input id="order_number" name="order_number" type="text" value="{{ track_value }}" placeholder="MCQ-20260414-AB12" />
+          </div>
+          <div class="tracker-field">
+            <label for="destination">Open</label>
+            <select id="destination" name="destination">
+              <option value="detail">Order detail</option>
+              <option value="receipt">Receipt</option>
+            </select>
+          </div>
+          <button type="submit" class="button button--primary">Track Order</button>
+        </form>
+        <div class="tracker-note">
+          <strong>{{ ordering_snapshot.ready_count }} ready now</strong>
+          <p>Orders already marked ready for pickup are surfaced across the site through in-app notifications.</p>
+        </div>
+      </div>
+    </aside>
+  </div>
+</section>
+
+<section class="launchpad section-panel">
+  <div class="launchpad__header">
+    <div>
+      <p class="eyebrow">User-side launchpad</p>
+      <h2>Buttons ready for the feature set in the README</h2>
+    </div>
+    <p>
+      The homepage now exposes the planned customer journey more clearly: account setup, menu browsing, cart,
+      instant ordering, scheduled pickup, checkout, receipt, live order tracking, and support.
+    </p>
+  </div>
+  <div class="launchpad__grid">
+    <article class="launch-card">
+      <p class="launch-card__kicker">Account</p>
+      <h3>Get customers in fast</h3>
+      <p>Keep account entry simple so returning customers can sign in quickly before placing or tracking an order.</p>
+      <div class="launch-card__actions">
+        <a class="feature-button feature-button--accent" href="/register">Register</a>
+        <a class="feature-button" href="/login">Login</a>
+      </div>
+    </article>
+    <article class="launch-card">
+      <p class="launch-card__kicker">Ordering</p>
+      <h3>Cover both ordering paths</h3>
+      <p>These buttons map directly to the two real customer journeys and both start in the menu, where customers choose dishes first.</p>
+      <div class="launch-card__actions">
+        <a class="feature-button feature-button--accent" href="/menu?fulfillment=instant">Instant Menu</a>
+        <a class="feature-button" href="/menu?fulfillment=scheduled">Scheduled Menu</a>
+        <a class="feature-button" href="/cart?fulfillment=instant">Cart</a>
+      </div>
+    </article>
+    <article class="launch-card">
+      <p class="launch-card__kicker">Checkout Flow</p>
+      <h3>Keep the next step obvious</h3>
+      <p>Once dishes are in the cart, customers can move into instant checkout, scheduled pickup planning, or order history without detours.</p>
+      <div class="launch-card__actions">
+        <a class="feature-button feature-button--accent" href="/checkout?fulfillment=instant">Instant Checkout</a>
+        <a class="feature-button" href="/pickup-planner?fulfillment=scheduled">Scheduled Pickup</a>
+        <a class="feature-button" href="/orders">Order History</a>
+      </div>
+    </article>
+    <article class="launch-card">
+      <p class="launch-card__kicker">Tracking</p>
+      <h3>Receipts and live updates</h3>
+      <p>Customers can jump back into tracking, receipt lookup, and live pickup notifications from one clear section.</p>
+      <div class="launch-card__actions">
+        <a class="feature-button feature-button--accent" href="/orders">Open Orders</a>
+        <a class="feature-button" href="#live-ordering">Track by Order Number</a>
+      </div>
+    </article>
+    <article class="launch-card">
+      <p class="launch-card__kicker">Support</p>
+      <h3>Help is always nearby</h3>
+      <p>The floating chatbox and phone contact keep help visible without interrupting the main ordering path.</p>
+      <div class="launch-card__actions">
+        <a class="feature-button feature-button--accent" href="tel:+61892485623">Call 08 9248 5623</a>
+        <a class="feature-button" href="tel:+61892485623">08 9248 5623</a>
+      </div>
+    </article>
   </div>
 </section>
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -1186,7 +1186,7 @@
       <p>Open the full menu or jump into the best sellers below.</p>
       <span class="homepage-flow__meta">Browse menu</span>
     </a>
-    <a class="homepage-flow__step" href="/menu?fulfillment=instant">
+    <a class="homepage-flow__step" href="/menu?fulfillment=scheduled">
       <span class="homepage-flow__number">2</span>
       <h3>Choose pickup</h3>
       <p>Order now for the counter or schedule a time that fits.</p>

--- a/templates/index.html
+++ b/templates/index.html
@@ -290,6 +290,10 @@
     font-size: 0.84rem;
   }
 
+  .homepage-flow + .street-gallery {
+    margin-top: clamp(1.6rem, 4vw, 3rem);
+  }
+
   .launchpad__header,
   .support-story__copy,
   .support-story__panel {
@@ -914,6 +918,7 @@
   }
 
   @media (max-width: 1180px) {
+    .homepage-flow__grid,
     .launchpad__grid {
       grid-template-columns: repeat(2, minmax(0, 1fr));
     }
@@ -922,6 +927,7 @@
   @media (max-width: 1080px) {
     .live-ops__grid,
     .support-story,
+    .homepage-flow__header,
     .launchpad__header,
     .street-gallery__header,
     .street-inspiration__header {
@@ -964,6 +970,7 @@
 
   @media (max-width: 720px) {
     .landing-hero--minimal,
+    .homepage-flow,
     .live-ops,
     .launchpad,
     .street-gallery,
@@ -977,6 +984,42 @@
       max-width: 24rem;
       justify-self: center;
       margin-top: 0.25rem;
+    }
+
+    .homepage-flow__header {
+      align-items: flex-start;
+      text-align: left;
+      margin-bottom: 0.8rem;
+    }
+
+    .homepage-flow__header h2 {
+      font-size: 1.45rem;
+    }
+
+    .homepage-flow__header p {
+      max-width: none;
+      line-height: 1.45;
+    }
+
+    .homepage-flow__grid {
+      display: grid;
+      grid-auto-flow: column;
+      grid-auto-columns: minmax(14.5rem, 78vw);
+      grid-template-columns: none;
+      overflow-x: auto;
+      padding-bottom: 0.35rem;
+      scroll-snap-type: x proximity;
+    }
+
+    .homepage-flow__step {
+      min-height: 8.6rem;
+      padding: 0.9rem;
+      border-radius: 18px;
+      scroll-snap-align: start;
+    }
+
+    .homepage-flow__step p {
+      line-height: 1.38;
     }
 
     .landing-hero__visual {

--- a/templates/index.html
+++ b/templates/index.html
@@ -394,14 +394,17 @@
 
   .street-gallery {
     position: relative;
-    padding: clamp(1.15rem, 2.4vw, 1.85rem);
-    border-radius: 32px;
-    border: 1px solid rgba(112, 85, 66, 0.12);
-    background:
-      radial-gradient(circle at 12% 0%, rgba(255, 223, 146, 0.2), transparent 42%),
-      linear-gradient(180deg, rgba(255, 252, 247, 0.98), rgba(247, 236, 220, 0.92)),
-      #fff;
-    box-shadow: 0 20px 40px rgba(53, 30, 20, 0.08);
+    margin-top: clamp(3.3rem, 7.8vw, 6rem);
+    padding: 0;
+    border-radius: 0;
+    border: 0;
+    background: transparent;
+    box-shadow: none;
+    overflow: visible;
+  }
+
+  .street-gallery.section-panel::before {
+    content: none;
   }
 
   .street-gallery__header {
@@ -411,7 +414,7 @@
     justify-content: center;
     gap: 1rem;
     align-items: center;
-    margin-bottom: 1rem;
+    margin-bottom: 2rem;
   }
 
   .street-gallery__header-copy {
@@ -483,6 +486,10 @@
     z-index: 1;
     overflow-x: auto;
     padding-bottom: 0.45rem;
+    margin-left: calc(-1 * clamp(0.8rem, 2vw, 1.3rem));
+    margin-right: calc(50% - 50vw);
+    padding-left: clamp(0.8rem, 2vw, 1.3rem);
+    padding-right: max(0.35rem, env(safe-area-inset-right));
     scroll-behavior: smooth;
     scroll-snap-type: x proximity;
     scrollbar-width: thin;
@@ -507,7 +514,7 @@
     display: grid;
     grid-auto-flow: column;
     grid-auto-columns: minmax(248px, 270px);
-    gap: 0.85rem;
+    gap: 1.3rem;
     width: max-content;
   }
 
@@ -692,7 +699,16 @@
     }
 
     .street-gallery__grid {
+      gap: 0.75rem;
       grid-auto-columns: minmax(78vw, 260px);
+    }
+
+    .street-gallery {
+      margin-top: clamp(1.2rem, 4vw, 1.9rem);
+    }
+
+    .street-gallery__header {
+      margin-bottom: 1rem;
     }
   }
 </style>

--- a/templates/index.html
+++ b/templates/index.html
@@ -393,68 +393,96 @@
   }
 
   .street-gallery {
-    padding: clamp(1.35rem, 3vw, 2rem);
+    position: relative;
+    padding: clamp(1.15rem, 2.4vw, 1.85rem);
+    border-radius: 32px;
+    border: 1px solid rgba(112, 85, 66, 0.12);
+    background:
+      radial-gradient(circle at 12% 0%, rgba(255, 223, 146, 0.2), transparent 42%),
+      linear-gradient(180deg, rgba(255, 252, 247, 0.98), rgba(247, 236, 220, 0.92)),
+      #fff;
+    box-shadow: 0 20px 40px rgba(53, 30, 20, 0.08);
   }
 
   .street-gallery__header {
     position: relative;
     z-index: 1;
     display: flex;
-    justify-content: space-between;
-    gap: 1.25rem;
-    align-items: end;
-    margin-bottom: 1.2rem;
+    justify-content: center;
+    gap: 1rem;
+    align-items: center;
+    margin-bottom: 1rem;
   }
 
   .street-gallery__header-copy {
-    max-width: 60ch;
+    display: flex;
+    justify-content: center;
+    width: 100%;
   }
 
   .street-gallery__header h2 {
-    margin: 0.3rem 0 0;
-    font-family: "Bricolage Grotesque", "Be Vietnam Pro", sans-serif;
-    font-size: clamp(1.8rem, 2.5vw, 2.8rem);
-  }
-
-  .street-gallery__header p {
-    margin: 0.85rem 0 0;
-    color: var(--text-muted);
-    line-height: 1.7;
+    margin: 0;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.42rem 0.92rem 0.34rem;
+    border-radius: 10px;
+    border: 1px solid rgba(41, 28, 55, 0.42);
+    font-family: "Bebas Neue", "Bricolage Grotesque", sans-serif;
+    font-size: clamp(2.05rem, 4.2vw, 3rem);
+    letter-spacing: 0.04em;
+    line-height: 1;
+    color: #1f1528;
+    background: linear-gradient(180deg, #d8b6ed 0%, #c89ee8 100%);
+    box-shadow:
+      0 5px 0 rgba(41, 28, 55, 0.28),
+      inset 0 1px 0 rgba(255, 255, 255, 0.6);
   }
 
   .street-gallery__controls {
     display: flex;
     align-items: center;
-    gap: 0.65rem;
+    gap: 0.45rem;
     flex-shrink: 0;
+    position: absolute;
+    right: 0;
+    top: 50%;
+    transform: translateY(-50%);
   }
 
   .street-gallery__hint {
-    font-family: "Bebas Neue", sans-serif;
-    letter-spacing: 0.14em;
-    color: var(--brand-orange);
+    font-size: 0.8rem;
+    font-weight: 700;
+    color: var(--text-muted);
     white-space: nowrap;
+    margin-right: 0.12rem;
   }
 
   .street-gallery__control {
-    width: 48px;
-    height: 48px;
-    border: 0;
+    width: 44px;
+    height: 44px;
+    border: 1px solid rgba(112, 85, 66, 0.2);
     border-radius: 999px;
     font: inherit;
-    font-size: 1.3rem;
+    font-size: 1.2rem;
     font-weight: 800;
-    color: var(--text-inverse);
-    background: linear-gradient(135deg, var(--brand-orange), var(--brand-red));
-    box-shadow: 0 16px 28px rgba(255, 106, 19, 0.22);
+    color: #28170f;
+    background: rgba(255, 255, 255, 0.94);
+    box-shadow: 0 10px 18px rgba(53, 30, 20, 0.12);
     cursor: pointer;
+    transition: transform 160ms ease, box-shadow 220ms ease;
+  }
+
+  .street-gallery__control:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 14px 22px rgba(53, 30, 20, 0.16);
   }
 
   .street-gallery__rail {
     position: relative;
     z-index: 1;
     overflow-x: auto;
-    padding-bottom: 0.55rem;
+    padding-bottom: 0.45rem;
     scroll-behavior: smooth;
     scroll-snap-type: x proximity;
     scrollbar-width: thin;
@@ -478,18 +506,18 @@
   .street-gallery__grid {
     display: grid;
     grid-auto-flow: column;
-    grid-auto-columns: minmax(285px, 340px);
-    gap: 1rem;
+    grid-auto-columns: minmax(248px, 270px);
+    gap: 0.85rem;
     width: max-content;
   }
 
   .gallery-card {
-    width: min(340px, calc(100vw - 3.4rem));
+    width: min(270px, calc(100vw - 3.2rem));
     overflow: hidden;
-    border-radius: 26px;
-    border: 1px solid rgba(112, 85, 66, 0.12);
-    background: rgba(255, 255, 255, 0.72);
-    box-shadow: 0 18px 36px rgba(53, 30, 20, 0.08);
+    border-radius: 14px;
+    border: 1px solid rgba(53, 30, 20, 0.35);
+    background: #fbf7ee;
+    box-shadow: 0 10px 24px rgba(53, 30, 20, 0.08);
     scroll-snap-align: start;
   }
 
@@ -497,36 +525,47 @@
     width: 100%;
     height: 250px;
     object-fit: cover;
+    object-position: center;
     display: block;
   }
 
   .gallery-card__body {
-    padding: 1rem 1rem 1.1rem;
+    padding: 0.8rem 0.86rem 0.9rem;
+    background: #fbf7ee;
+    border-top: 1px solid rgba(53, 30, 20, 0.22);
+    display: block;
   }
 
   .gallery-card__title-row {
     display: flex;
     align-items: baseline;
     justify-content: space-between;
-    gap: 0.7rem;
+    gap: 0.5rem;
   }
 
   .gallery-card h3 {
-    margin: 0 0 0.45rem;
+    margin: 0;
     font-family: "Bricolage Grotesque", "Be Vietnam Pro", sans-serif;
-    font-size: 1.2rem;
+    font-size: 1.06rem;
+    line-height: 1.22;
+    letter-spacing: -0.01em;
   }
 
   .gallery-card__price {
-    font-weight: 800;
+    font-size: 0.96rem;
+    font-weight: 700;
     color: var(--brand-red);
     white-space: nowrap;
   }
 
   .gallery-card p {
-    margin: 0;
+    margin: 0.35rem 0 0;
+    font-size: 0.88rem;
     color: var(--text-muted);
-    line-height: 1.45;
+    line-height: 1.4;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
   }
 
   .support-story {
@@ -575,9 +614,14 @@
     .support-story,
     .launchpad__header,
     .street-gallery__header {
-      grid-template-columns: 1fr;
       flex-direction: column;
-      align-items: flex-start;
+      align-items: center;
+      gap: 0.75rem;
+    }
+
+    .street-gallery__controls {
+      position: static;
+      transform: none;
     }
   }
 
@@ -648,7 +692,7 @@
     }
 
     .street-gallery__grid {
-      grid-auto-columns: minmax(82vw, 300px);
+      grid-auto-columns: minmax(78vw, 260px);
     }
   }
 </style>

--- a/templates/index.html
+++ b/templates/index.html
@@ -1005,68 +1005,6 @@
   </div>
 </section>
 
-<section class="launchpad section-panel">
-  <div class="launchpad__header">
-    <div>
-      <p class="eyebrow">User-side launchpad</p>
-      <h2>Buttons ready for the feature set in the README</h2>
-    </div>
-    <p>
-      The homepage now exposes the planned customer journey more clearly: account setup, menu browsing, cart,
-      instant ordering, scheduled pickup, checkout, receipt, live order tracking, and support.
-    </p>
-  </div>
-  <div class="launchpad__grid">
-    <article class="launch-card">
-      <p class="launch-card__kicker">Account</p>
-      <h3>Get customers in fast</h3>
-      <p>Keep account entry simple so returning customers can sign in quickly before placing or tracking an order.</p>
-      <div class="launch-card__actions">
-        <a class="feature-button feature-button--accent" href="/register">Register</a>
-        <a class="feature-button" href="/login">Login</a>
-      </div>
-    </article>
-    <article class="launch-card">
-      <p class="launch-card__kicker">Ordering</p>
-      <h3>Cover both ordering paths</h3>
-      <p>These buttons map directly to the two real customer journeys and both start in the menu, where customers choose dishes first.</p>
-      <div class="launch-card__actions">
-        <a class="feature-button feature-button--accent" href="/menu?fulfillment=instant">Instant Menu</a>
-        <a class="feature-button" href="/menu?fulfillment=scheduled">Scheduled Menu</a>
-        <a class="feature-button" href="/cart?fulfillment=instant">Cart</a>
-      </div>
-    </article>
-    <article class="launch-card">
-      <p class="launch-card__kicker">Checkout Flow</p>
-      <h3>Keep the next step obvious</h3>
-      <p>Once dishes are in the cart, customers can move into instant checkout, scheduled pickup planning, or order history without detours.</p>
-      <div class="launch-card__actions">
-        <a class="feature-button feature-button--accent" href="/checkout?fulfillment=instant">Instant Checkout</a>
-        <a class="feature-button" href="/pickup-planner?fulfillment=scheduled">Scheduled Pickup</a>
-        <a class="feature-button" href="/orders">Order History</a>
-      </div>
-    </article>
-    <article class="launch-card">
-      <p class="launch-card__kicker">Tracking</p>
-      <h3>Receipts and live updates</h3>
-      <p>Customers can jump back into tracking, receipt lookup, and live pickup notifications from one clear section.</p>
-      <div class="launch-card__actions">
-        <a class="feature-button feature-button--accent" href="/orders">Open Orders</a>
-        <a class="feature-button" href="#live-ordering">Track by Order Number</a>
-      </div>
-    </article>
-    <article class="launch-card">
-      <p class="launch-card__kicker">Support</p>
-      <h3>Help is always nearby</h3>
-      <p>The floating chatbox and phone contact keep help visible without interrupting the main ordering path.</p>
-      <div class="launch-card__actions">
-        <a class="feature-button feature-button--accent" href="tel:+61892485623">Call 08 9248 5623</a>
-        <a class="feature-button" href="tel:+61892485623">08 9248 5623</a>
-      </div>
-    </article>
-  </div>
-</section>
-
 <section class="support-story section-panel">
   <div class="support-story__copy">
     <p class="eyebrow">MCQ Supermarket</p>

--- a/templates/index.html
+++ b/templates/index.html
@@ -595,6 +595,195 @@
     text-overflow: ellipsis;
   }
 
+  .street-inspiration {
+    position: relative;
+    margin-top: clamp(2.5rem, 6vw, 4.5rem);
+    padding: 0;
+    border-radius: 0;
+    border: 0;
+    background: transparent;
+    box-shadow: none;
+    overflow: visible;
+  }
+
+  .street-inspiration.section-panel::before {
+    content: none;
+  }
+
+  .street-inspiration__header {
+    position: relative;
+    z-index: 1;
+    display: flex;
+    justify-content: center;
+    gap: 1rem;
+    align-items: center;
+    margin-bottom: 2rem;
+  }
+
+  .street-inspiration__header-copy {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    text-align: center;
+    gap: 0.4rem;
+  }
+
+  .street-inspiration__header h2 {
+    margin: 0;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.42rem 0.92rem 0.34rem;
+    border-radius: 10px;
+    border: 1px solid rgba(0, 95, 106, 0.42);
+    font-family: "Bebas Neue", "Bricolage Grotesque", sans-serif;
+    font-size: clamp(2.05rem, 4.2vw, 3rem);
+    letter-spacing: 0.04em;
+    line-height: 1;
+    color: #0a3d42;
+    background: linear-gradient(180deg, #b6edd8 0%, #9ee8c8 100%);
+    box-shadow:
+      0 5px 0 rgba(0, 95, 106, 0.28),
+      inset 0 1px 0 rgba(255, 255, 255, 0.6);
+  }
+
+  .street-inspiration__header p {
+    margin: 0.4rem 0 0;
+    max-width: 50ch;
+    color: var(--text-muted);
+    font-size: 0.95rem;
+    line-height: 1.6;
+  }
+
+  .street-inspiration__controls {
+    display: flex;
+    align-items: center;
+    gap: 0.45rem;
+    flex-shrink: 0;
+    position: absolute;
+    right: 0;
+    top: 50%;
+    transform: translateY(-50%);
+  }
+
+  .street-inspiration__hint {
+    font-size: 0.8rem;
+    font-weight: 700;
+    color: var(--text-muted);
+    white-space: nowrap;
+    margin-right: 0.12rem;
+  }
+
+  .street-inspiration__control {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 36px;
+    height: 36px;
+    border: 1.5px solid rgba(112, 85, 66, 0.18);
+    border-radius: 10px;
+    font: inherit;
+    font-size: 0;
+    color: #3d2518;
+    background: rgba(255, 255, 255, 0.92);
+    backdrop-filter: blur(6px);
+    box-shadow: 0 2px 8px rgba(53, 30, 20, 0.08);
+    cursor: pointer;
+    transition: background 180ms ease, border-color 180ms ease, transform 140ms ease, box-shadow 180ms ease;
+  }
+
+  .street-inspiration__control:hover {
+    background: rgba(0, 111, 116, 0.08);
+    border-color: rgba(0, 111, 116, 0.4);
+    transform: translateY(-1px);
+    box-shadow: 0 4px 12px rgba(0, 111, 116, 0.12);
+  }
+
+  .street-inspiration__control:active {
+    transform: scale(0.94);
+    box-shadow: 0 1px 4px rgba(53, 30, 20, 0.1);
+  }
+
+  .street-inspiration__control svg {
+    width: 18px;
+    height: 18px;
+    stroke: currentColor;
+    stroke-width: 2.2;
+    stroke-linecap: round;
+    stroke-linejoin: round;
+    fill: none;
+  }
+
+  .street-inspiration__rail {
+    position: relative;
+    z-index: 1;
+    overflow-x: auto;
+    padding-bottom: 0.45rem;
+    margin-left: calc(-1 * clamp(0.8rem, 2vw, 1.3rem));
+    margin-right: calc(50% - 50vw);
+    padding-left: clamp(0.8rem, 2vw, 1.3rem);
+    padding-right: max(0.35rem, env(safe-area-inset-right));
+    scroll-behavior: smooth;
+    scroll-snap-type: x proximity;
+    scrollbar-width: none;
+  }
+
+  .street-inspiration__rail::-webkit-scrollbar {
+    display: none;
+  }
+
+  .street-inspiration__grid {
+    display: grid;
+    grid-auto-flow: column;
+    grid-auto-columns: minmax(260px, 290px);
+    gap: 1.3rem;
+    width: max-content;
+  }
+
+  .inspiration-card {
+    display: block;
+    width: min(290px, calc(100vw - 3.2rem));
+    overflow: hidden;
+    border-radius: var(--radius-xl, 18px);
+    border: 1px solid var(--line-soft, rgba(112, 85, 66, 0.12));
+    background: rgba(255, 255, 255, 0.72);
+    box-shadow: 0 18px 36px rgba(53, 30, 20, 0.08);
+    scroll-snap-align: start;
+    transition: background 220ms ease, transform 220ms ease;
+  }
+
+  .inspiration-card:hover {
+    background: rgba(255, 255, 255, 0.92);
+    transform: translateY(-2px);
+  }
+
+  .inspiration-card img {
+    width: 100%;
+    height: 220px;
+    object-fit: cover;
+    object-position: center;
+    display: block;
+    border-bottom: 1px solid rgba(112, 85, 66, 0.1);
+  }
+
+  .inspiration-card__body {
+    padding: 0.85rem 0.95rem 1rem;
+  }
+
+  .inspiration-card h3 {
+    margin: 0.55rem 0 0.35rem;
+    font-family: "Bricolage Grotesque", "Be Vietnam Pro", sans-serif;
+    font-size: 1.08rem;
+    line-height: 1.25;
+  }
+
+  .inspiration-card p {
+    margin: 0;
+    font-size: 0.88rem;
+    color: var(--text-muted);
+    line-height: 1.55;
+  }
+
   .support-story {
     display: grid;
     grid-template-columns: minmax(0, 1.1fr) minmax(300px, 0.9fr);
@@ -640,13 +829,15 @@
     .live-ops__grid,
     .support-story,
     .launchpad__header,
-    .street-gallery__header {
+    .street-gallery__header,
+    .street-inspiration__header {
       flex-direction: column;
       align-items: center;
       gap: 0.75rem;
     }
 
-    .street-gallery__controls {
+    .street-gallery__controls,
+    .street-inspiration__controls {
       position: static;
       transform: none;
     }
@@ -682,6 +873,7 @@
     .live-ops,
     .launchpad,
     .street-gallery,
+    .street-inspiration,
     .support-story {
       padding: 1rem;
     }
@@ -756,6 +948,51 @@
 
     .street-gallery__header {
       margin-bottom: 1rem;
+    }
+
+    .street-inspiration {
+      margin-top: clamp(1.2rem, 4vw, 1.9rem);
+    }
+
+    .street-inspiration__header {
+      margin-bottom: 1rem;
+    }
+
+    .street-inspiration__controls {
+      width: auto;
+      justify-content: flex-end;
+      gap: 0.5rem;
+    }
+
+    .street-inspiration__hint {
+      display: none;
+    }
+
+    .street-inspiration__control {
+      width: 32px;
+      height: 32px;
+      border-radius: 8px;
+    }
+
+    .street-inspiration__control svg {
+      width: 16px;
+      height: 16px;
+    }
+
+    .street-inspiration__rail {
+      margin-left: 0;
+      margin-right: 0;
+      padding-left: 0;
+      padding-right: 0;
+    }
+
+    .street-inspiration__grid {
+      gap: 0.75rem;
+      grid-auto-columns: minmax(220px, 260px);
+    }
+
+    .inspiration-card {
+      width: 260px;
     }
   }
 </style>
@@ -1005,6 +1242,115 @@
   </div>
 </section>
 
+<section class="street-inspiration section-panel">
+  <div class="street-inspiration__header">
+    <div class="street-inspiration__header-copy">
+      <h2>Street Food Inspiration</h2>
+      <p>The images and stories behind the MCQ street-food identity — from Ben Thanh Market to night-stall grills.</p>
+    </div>
+    <div class="street-inspiration__controls" aria-label="Inspiration gallery controls">
+      <span class="street-inspiration__hint">Swipe or slide</span>
+      <button
+        class="street-inspiration__control"
+        type="button"
+        data-inspiration-shift="-1"
+        aria-label="Scroll inspiration left"
+      >
+        <svg viewBox="0 0 24 24"><polyline points="15 18 9 12 15 6"/></svg>
+      </button>
+      <button
+        class="street-inspiration__control"
+        type="button"
+        data-inspiration-shift="1"
+        aria-label="Scroll inspiration right"
+      >
+        <svg viewBox="0 0 24 24"><polyline points="9 6 15 12 9 18"/></svg>
+      </button>
+    </div>
+  </div>
+  <div class="street-inspiration__rail" id="street-inspiration-rail">
+  <div class="street-inspiration__grid">
+    <article class="inspiration-card">
+      <img src="{{ url_for('static', filename='images/brand/benthanh.jpg') }}" alt="Ben Thanh Market inspired artwork" />
+      <div class="inspiration-card__body">
+        <h3>Ben Thanh Signature</h3>
+        <p>Your attached Ben Thanh illustration now anchors the Saigon identity instead of being a loose reference.</p>
+      </div>
+    </article>
+    <article class="inspiration-card">
+      <img src="{{ url_for('static', filename='images/inspiration/street-food-life.jpg') }}" alt="Street food scene inspiration" />
+      <div class="inspiration-card__body">
+        <h3>Street-side Energy</h3>
+        <p>Used to bring in the feel of everyday Vietnamese food culture and a busier, more lived-in atmosphere.</p>
+      </div>
+    </article>
+    <article class="inspiration-card">
+      <img src="{{ url_for('static', filename='images/inspiration/streetfood-1.jpg') }}" alt="Vietnamese tray meal with herbs and noodles" />
+      <div class="inspiration-card__body">
+        <h3>Tray-and-Herb Street Detail</h3>
+        <p>This image adds a more casual curb-side meal moment and helps the feature pages feel less repetitive.</p>
+      </div>
+    </article>
+    <article class="inspiration-card">
+      <img src="{{ url_for('static', filename='images/inspiration/streetfood-4.jpg') }}" alt="Vietnamese floating market boats" />
+      <div class="inspiration-card__body">
+        <h3>Floating Market Colour</h3>
+        <p>Boat markets add a broader Vietnam mood and make the brand world feel bigger than one single food counter.</p>
+      </div>
+    </article>
+    <article class="inspiration-card">
+      <img src="{{ url_for('static', filename='images/inspiration/streetfood-5.jpg') }}" alt="Vietnamese produce market stall" />
+      <div class="inspiration-card__body">
+        <h3>Wet Market Produce</h3>
+        <p>Vegetable baskets and market colour help the site feel rooted in daily Vietnamese food culture, not just plated dishes.</p>
+      </div>
+    </article>
+    <article class="inspiration-card">
+      <img src="{{ url_for('static', filename='images/inspiration/streetfood-6.jpg') }}" alt="Vietnamese grilled meat over open flame" />
+      <div class="inspiration-card__body">
+        <h3>Charcoal Grill Heat</h3>
+        <p>This adds real night-stall intensity and gives the homepage a hotter, more energetic food-street feeling.</p>
+      </div>
+    </article>
+    <article class="inspiration-card">
+      <img src="{{ url_for('static', filename='images/inspiration/streetfood-7.jpg') }}" alt="Vietnamese shrimp rice paper rolls" />
+      <div class="inspiration-card__body">
+        <h3>Fresh Roll Texture</h3>
+        <p>Transparent rice paper and dipping sauce introduce a cleaner, cooler visual note among the hotter grill scenes.</p>
+      </div>
+    </article>
+    <article class="inspiration-card">
+      <img src="{{ url_for('static', filename='images/inspiration/streetfood-8.jpg') }}" alt="Vietnamese banh xeo cooking and serving" />
+      <div class="inspiration-card__body">
+        <h3>Kitchen-to-Plate Motion</h3>
+        <p>The split cooking-and-plating shot helps communicate that MCQ is both a real kitchen and a digital ordering experience.</p>
+      </div>
+    </article>
+    <article class="inspiration-card">
+      <img src="{{ url_for('static', filename='images/inspiration/streetfood-9.jpg') }}" alt="Vietnamese skewers and fish balls street stall" />
+      <div class="inspiration-card__body">
+        <h3>Skewer Bar Variety</h3>
+        <p>Rows of skewers and snacks make the site feel fuller and more spontaneous, like browsing a real street-food lane.</p>
+      </div>
+    </article>
+    <article class="inspiration-card">
+      <img src="{{ url_for('static', filename='images/inspiration/streetfood-10.jpg') }}" alt="Vietnamese market grill and skewer spread" />
+      <div class="inspiration-card__body">
+        <h3>Street Stall Abundance</h3>
+        <p>The dense market spread pushes the overall design closer to a lively Saigon snack counter instead of a quiet cafe layout.</p>
+      </div>
+    </article>
+    <article class="inspiration-card">
+      <img src="{{ url_for('static', filename='images/inspiration/noodle-bowl-unsplash.jpg') }}" alt="Vietnamese noodle bowl inspiration" />
+      <div class="inspiration-card__body">
+        <h3>Bowl-Led Appetite Appeal</h3>
+        <p>A strong food close-up still matters, so the noodle bowl stays as a cleaner appetite anchor among the busier street scenes.</p>
+      </div>
+    </article>
+  </div>
+  </div>
+</section>
+
 <section class="support-story section-panel">
   <div class="support-story__copy">
     <p class="eyebrow">MCQ Supermarket</p>
@@ -1059,16 +1405,30 @@
     const galleryRail = document.getElementById('street-gallery-rail');
     const galleryButtons = document.querySelectorAll('[data-gallery-shift]');
 
-    if (!galleryRail || !galleryButtons.length) return;
-
-    galleryButtons.forEach((button) => {
-      button.addEventListener('click', () => {
-        const card = galleryRail.querySelector('.gallery-card');
-        const step = card ? card.getBoundingClientRect().width + 16 : galleryRail.clientWidth * 0.8;
-        const direction = Number(button.dataset.galleryShift || '1');
-        galleryRail.scrollBy({ left: step * direction, behavior: 'smooth' });
+    if (galleryRail && galleryButtons.length) {
+      galleryButtons.forEach((button) => {
+        button.addEventListener('click', () => {
+          const card = galleryRail.querySelector('.gallery-card');
+          const step = card ? card.getBoundingClientRect().width + 16 : galleryRail.clientWidth * 0.8;
+          const direction = Number(button.dataset.galleryShift || '1');
+          galleryRail.scrollBy({ left: step * direction, behavior: 'smooth' });
+        });
       });
-    });
+    }
+
+    const inspirationRail = document.getElementById('street-inspiration-rail');
+    const inspirationButtons = document.querySelectorAll('[data-inspiration-shift]');
+
+    if (inspirationRail && inspirationButtons.length) {
+      inspirationButtons.forEach((button) => {
+        button.addEventListener('click', () => {
+          const card = inspirationRail.querySelector('.inspiration-card');
+          const step = card ? card.getBoundingClientRect().width + 16 : inspirationRail.clientWidth * 0.8;
+          const direction = Number(button.dataset.inspirationShift || '1');
+          inspirationRail.scrollBy({ left: step * direction, behavior: 'smooth' });
+        });
+      });
+    }
   })();
 </script>
 {% endblock %}


### PR DESCRIPTION
- replace street-gallery inspiration cards with curated best-seller menu item cards and item-detail links.
- removed user-side launchpad for simplicity

before
<img width="2824" height="1530" alt="CleanShot 2026-05-10 at 22 22 18@2x" src="https://github.com/user-attachments/assets/4366057b-d454-4f9f-a224-f8c74e444da3" />

after
<img width="2852" height="1408" alt="CleanShot 2026-05-10 at 22 21 11" src="https://github.com/user-attachments/assets/21ddc084-f5e8-4b5a-8f71-5c0122cd77fd" />
